### PR TITLE
Add cannon contract loading

### DIFF
--- a/src/synthetix/contracts/contracts.py
+++ b/src/synthetix/contracts/contracts.py
@@ -1,15 +1,90 @@
 import os
 import json
 import glob
+import zlib
+import requests
+from web3 import Web3
 
-def load_contracts(network_id):
-    """Loads the contracts for the given network id"""
-    # get all filenames from directory `./deployments/[network_id]`
-    deployment_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'deployments', f'{network_id}')
-    deployment_files = glob.glob(os.path.join(deployment_dir, '*.json'))
+def load_contracts(snx):
+    """loads the contracts for a synthetix instance and overrides with cannon if set"""
+    # first load local contracts
+    contracts = load_local_contracts(snx)
 
-    contracts = {
-        os.path.splitext(os.path.basename(contract))[0]: json.load(open(contract))
-        for contract in deployment_files
-    }
+    # if true, load cannon contracts and override local contracts
+    if snx.cannon_config is not None:
+        deployment_hash = get_deployment_hash(snx)
+        cannon_contracts = fetch_deploy_from_ipfs(snx, deployment_hash)
+        contracts.update(cannon_contracts)
     return contracts
+
+def load_local_contracts(snx):
+    """loads the contracts for a synthetix instance"""
+    deployment_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'deployments', f'{snx.network_id}')
+    contracts = load_json_files_from_directory(deployment_dir)
+    return contracts
+
+def load_json_files_from_directory(directory):
+    """load json files from a given directory"""
+    json_files = glob.glob(os.path.join(directory, '*.json'))
+    return {
+        os.path.splitext(os.path.basename(file))[0]: json.load(open(file))
+        for file in json_files
+    }
+
+def get_deployment_hash(snx):
+    provider_rpc = snx.mainnet_rpc
+    w3 = Web3(Web3.HTTPProvider(provider_rpc)) if provider_rpc.startswith('http') else Web3(Web3.WebsocketProvider(provider_rpc))
+
+    deployment_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'deployments', '1')
+    cannon_file = os.path.join(deployment_dir, 'CannonRegistry.json')
+    with open(cannon_file, 'r') as file:
+        cannon_contract_def = json.load(file)
+
+    contract = w3.eth.contract(address=cannon_contract_def["address"], abi=cannon_contract_def["abi"])
+    
+    chain_id = snx.network_id
+    package = encode_string(snx.cannon_config['package'])
+    version = encode_string(snx.cannon_config['version'])
+    preset = encode_string(str(chain_id) + "-" + snx.cannon_config['preset'])
+    
+    ipfs_loc = contract.functions.getPackageUrl(package, version, preset).call()
+    ipfs_hash = ipfs_loc.split("/")[-1]
+    return ipfs_hash
+
+def encode_string(string, length=66, pad_char="0"):
+    """encode a string to a fixed length for contract interaction"""
+    return Web3.to_hex(text=string).ljust(length, pad_char)
+
+def fetch_deploy_from_ipfs(snx, ipfs_hash):
+    url = f"{snx.ipfs_gateway}/{ipfs_hash}"
+    response = requests.get(url)
+    data = zlib.decompress(response.content)
+    data = json.loads(data)
+
+    deployment = parse_contracts(snx, data)
+    return deployment
+
+def parse_contracts(snx, deploy_data):
+    contracts = dict()
+    recursive_search(deploy_data, contracts)      
+    return {
+        k: {
+            'address': v["address"],
+            'abi': v["abi"],
+            'contract': snx.web3.eth.contract(address=v["address"], abi=v["abi"])
+        }
+        for k, v in contracts.items()
+    }
+
+def recursive_search(deploy_data, contracts):
+    """recursively search through deployment data to extract contracts"""
+    if isinstance(deploy_data, dict):
+        for key, value in deploy_data.items():
+            if key == "contracts" and value:
+                for contract_name, artifacts in value.items():
+                    contracts[contract_name] = artifacts
+            if isinstance(value, (dict, list)):
+                recursive_search(value, contracts)
+    elif isinstance(deploy_data, list):
+        for item in deploy_data:
+            recursive_search(item, contracts)

--- a/src/synthetix/contracts/deployments/1/CannonRegistry.json
+++ b/src/synthetix/contracts/deployments/1/CannonRegistry.json
@@ -1,0 +1,599 @@
+{
+    "address": "0x8E5C7EFC9636A6A0408A46BB7F617094B81e5dba",
+    "abi": [
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "ImplementationIsSterile",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "name",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "InvalidName",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidTags",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "string",
+                    "name": "url",
+                    "type": "string"
+                }
+            ],
+            "name": "InvalidUrl",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "NoChange",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "contr",
+                    "type": "address"
+                }
+            ],
+            "name": "NotAContract",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "addr",
+                    "type": "address"
+                }
+            ],
+            "name": "NotNominated",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "PackageNotFound",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "addr",
+                    "type": "address"
+                }
+            ],
+            "name": "Unauthorized",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "Unauthorized",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "UpgradeSimulationFailed",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "ZeroAddress",
+            "type": "error"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerChanged",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerNominated",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "name",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "tag",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "variant",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "deployUrl",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "metaUrl",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "PackagePublish",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "name",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "verifier",
+                    "type": "address"
+                }
+            ],
+            "name": "PackageUnverify",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "name",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "verifier",
+                    "type": "address"
+                }
+            ],
+            "name": "PackageVerify",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "self",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "Upgraded",
+            "type": "event"
+        },
+        {
+            "inputs": [],
+            "name": "MIN_PACKAGE_NAME_LENGTH",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "acceptOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "acceptPackageOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getAdditionalDeployers",
+            "outputs": [
+                {
+                    "internalType": "address[]",
+                    "name": "additionalDeployers",
+                    "type": "address[]"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "getImplementation",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageVersionName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageVariant",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getPackageMeta",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getPackageNominatedOwner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getPackageOwner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageVersionName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageVariant",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getPackageUrl",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes[]",
+                    "name": "data",
+                    "type": "bytes[]"
+                }
+            ],
+            "name": "multicall",
+            "outputs": [
+                {
+                    "internalType": "bytes[]",
+                    "name": "results",
+                    "type": "bytes[]"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newNominatedOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "nominateNewOwner",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "address",
+                    "name": "_newPackageOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "nominatePackageOwner",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "nominatedOwner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "owner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "_variant",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32[]",
+                    "name": "_packageTags",
+                    "type": "bytes32[]"
+                },
+                {
+                    "internalType": "string",
+                    "name": "_packageDeployUrl",
+                    "type": "string"
+                },
+                {
+                    "internalType": "string",
+                    "name": "_packageMetaUrl",
+                    "type": "string"
+                }
+            ],
+            "name": "publish",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "renounceNomination",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "address[]",
+                    "name": "additionalDeployers",
+                    "type": "address[]"
+                }
+            ],
+            "name": "setAdditionalDeployers",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newImplementation",
+                    "type": "address"
+                }
+            ],
+            "name": "simulateUpgradeTo",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "unverifyPackage",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_newImplementation",
+                    "type": "address"
+                }
+            ],
+            "name": "upgradeTo",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_name",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "validatePackageName",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "verifyPackage",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        }
+    ]
+}

--- a/src/synthetix/synthetix.py
+++ b/src/synthetix/synthetix.py
@@ -42,8 +42,9 @@ class Synthetix:
 
     :param str provider_rpc: An RPC endpoint to use for the provider that interacts
         with the smart contracts. This must match the ``network_id``.
-    :param str provider_rpc: A mainnet RPC endpoint to use for the provider that
+    :param str mainnet_rpc: A mainnet RPC endpoint to use for the provider that
         fetches deployments from the Cannon registry.
+    :param str ipfs_gateway: An IPFS gateway to use for fetching deployments.
     :param str address: Wallet address to use as a default. If a private key is
         specified, this address will be used to sign transactions.
     :param str private_key: Private key of the provided wallet address. If specified,


### PR DESCRIPTION
Add functionality to specify a cannon deployment and fetch the contract addresses and ABIs. Since not all contracts may be in the specified deployment, the config acts as an override for the hard-coded contracts.

Usage:
```
snx = Synthetix(
    provider_rpc=os.getenv('BASE_TESTNET_RPC'), # A Base Goerli RPC endpoint
    network_id=84531, # Base Goerli
    cannon_config = {
        'package': 'synthetix-omnibus',
        'version': '3.3.3-dev.e141cd8c',
        'preset': 'andromeda'
    }
)
```