### PR TITLE
Bug: multicall `require_success`

### DIFF
--- a/src/synthetix/utils/multicall.py
+++ b/src/synthetix/utils/multicall.py
@@ -198,7 +198,7 @@ def multicall_erc7412(
     these_calls = [
         (
             contract.address,
-            False,
+            True,
             0,
             contract.encodeABI(fn_name=function_name, args=args),
         )


### PR DESCRIPTION
Fix a bug where `require_success` is set to `False` on multicalls, skipping the ERC7412 data fetching.