### PR TITLE
Pyth Updates

### DIFF
--- a/src/synthetix/perps/perps.py
+++ b/src/synthetix/perps/perps.py
@@ -1,7 +1,7 @@
 """Module for interacting with Synthetix Perps V3."""
 
 import time
-from eth_utils import decode_hex
+from eth_utils import encode_hex, decode_hex
 from ..utils import ether_to_wei, wei_to_ether
 from ..utils.multicall import (
     call_erc7412,
@@ -45,15 +45,10 @@ class Perps:
     :rtype: Perps
     """
 
-    def __init__(self, snx, pyth, default_account_id: int = None):
+    def __init__(self, snx, default_account_id: int = None):
         self.snx = snx
-        self.pyth = pyth
         self.logger = snx.logger
-
-        if "PythERC7412Wrapper" in snx.contracts:
-            self.erc7412_enabled = False
-        else:
-            self.erc7412_enabled = False
+        self.erc7412_enabled = True
 
         # check if perps is deployed on this network
         if "PerpsMarketProxy" in snx.contracts:
@@ -68,6 +63,14 @@ class Perps:
 
             try:
                 self.get_markets()
+
+                # update pyth price feed ids
+                self.snx.pyth.price_feed_ids.update(
+                    {
+                        market: self.markets_by_name[market]["feed_id"]
+                        for market in self.markets_by_name
+                    }
+                )
             except Exception as e:
                 self.logger.warning(f"Failed to fetch markets: {e}")
 
@@ -125,10 +128,28 @@ class Perps:
             ]
 
         # fetch the data from pyth
-        feed_ids = [
-            self.snx.pyth.price_feed_ids[market_name] for market_name in market_names
+        filtered_market_names = [
+            m for m in market_names if m in self.snx.pyth.price_feed_ids
         ]
-        price_update_data = self.snx.pyth.get_feeds_data(feed_ids)
+        # if no markets, return an empty list
+        if len(filtered_market_names) == 0:
+            return []
+
+        feed_ids = [
+            self.snx.pyth.price_feed_ids[market_name]
+            for market_name in filtered_market_names
+        ]
+        if not self.snx.is_fork:
+            price_update_data = self.snx.pyth.get_feeds_data(feed_ids)
+        else:
+            # if it's a fork, get the price for the latest block
+            # this avoids providing "future" prices to the contract on a fork
+            block = self.snx.web3.eth.get_block("latest")
+            pyth_responses = [
+                self.snx.pyth.get_benchmark_data(feed_id, block.timestamp)
+                for feed_id in feed_ids
+            ]
+            price_update_data = [response[0] for response in pyth_responses if response]
 
         # prepare the oracle call
         raw_feed_ids = [decode_hex(feed_id) for feed_id in feed_ids]
@@ -143,7 +164,7 @@ class Perps:
         value = len(market_names)
 
         # return this formatted for the multicall
-        return (to, True, value, data)
+        return [(to, True, value, data)]
 
     # read
     # TODO: get_market_settings
@@ -190,8 +211,22 @@ class Perps:
 
         # fetch the market summaries
         market_summaries = self.get_market_summaries(market_ids)
-
         markets_by_id = {summary["market_id"]: summary for summary in market_summaries}
+
+        # fetch settlement strategies to get feed_ids
+        settlement_strategy_inputs = [(market_id, 0) for market_id in market_ids]
+        settlement_strategies = multicall_erc7412(
+            self.snx,
+            self.market_proxy,
+            "getSettlementStrategy",
+            settlement_strategy_inputs,
+        )
+        # loop through results and add to markets_by_id
+        for ind, strategy in enumerate(settlement_strategies):
+            feed_id = strategy[4]
+            markets_by_id[market_ids[ind]]["feed_id"] = encode_hex(feed_id)
+
+        # make markets by market name
         markets_by_name = {
             summary["market_name"]: summary for summary in market_summaries
         }
@@ -253,8 +288,7 @@ class Perps:
         # TODO: Fetch for market names
         # get fresh prices to provide to the oracle
         if self.erc7412_enabled:
-            oracle_call = self._prepare_oracle_call()
-            calls = [oracle_call]
+            calls = self._prepare_oracle_call()
         else:
             calls = []
 
@@ -313,8 +347,7 @@ class Perps:
 
         # get a fresh price to provide to the oracle
         if self.erc7412_enabled:
-            oracle_call = self._prepare_oracle_call([market_name])
-            calls = [oracle_call]
+            calls = self._prepare_oracle_call()
         else:
             calls = []
 
@@ -433,8 +466,7 @@ class Perps:
 
         # get fresh prices to provide to the oracle
         if self.erc7412_enabled:
-            oracle_call = self._prepare_oracle_call()
-            calls = [oracle_call]
+            calls = self._prepare_oracle_call()
         else:
             calls = []
 
@@ -523,8 +555,7 @@ class Perps:
 
         # get fresh prices to provide to the oracle
         if self.erc7412_enabled:
-            oracle_call = self._prepare_oracle_call()
-            calls = [oracle_call]
+            calls = self._prepare_oracle_call()
         else:
             calls = []
 
@@ -546,8 +577,7 @@ class Perps:
 
         # get fresh prices to provide to the oracle
         if self.erc7412_enabled:
-            oracle_call = self._prepare_oracle_call()
-            calls = [oracle_call]
+            calls = self._prepare_oracle_call()
         else:
             calls = []
 
@@ -588,8 +618,7 @@ class Perps:
 
         # get a fresh price to provide to the oracle
         if self.erc7412_enabled:
-            oracle_call = self._prepare_oracle_call([market_name])
-            calls = [oracle_call]
+            calls = self._prepare_oracle_call([market_name])
         else:
             calls = []
 
@@ -654,8 +683,7 @@ class Perps:
 
         # get a fresh price to provide to the oracle
         if self.erc7412_enabled:
-            oracle_call = self._prepare_oracle_call(market_names)
-            calls = [oracle_call]
+            calls = self._prepare_oracle_call(market_names)
         else:
             calls = []
 
@@ -909,12 +937,6 @@ class Perps:
 
         # get fresh prices to provide to the oracle
         market_name = self._resolve_market(order["market_id"], None)[1]
-        if self.erc7412_enabled:
-            oracle_call = self._prepare_oracle_call([market_name])
-            calls = [oracle_call]
-        else:
-            calls = []
-
         # prepare the transaction
         tx_tries = 0
         while tx_tries < max_tx_tries:
@@ -924,7 +946,6 @@ class Perps:
                     self.market_proxy,
                     "settleOrder",
                     [account_id],
-                    calls=calls,
                 )
             except Exception as e:
                 self.logger.error(f"settleOrder error: {e}")

--- a/src/synthetix/perps/perps.py
+++ b/src/synthetix/perps/perps.py
@@ -65,7 +65,7 @@ class Perps:
                 self.get_markets()
 
                 # update pyth price feed ids
-                self.snx.pyth.price_feed_ids.update(
+                self.snx.pyth.update_price_feed_ids(
                     {
                         market: self.markets_by_name[market]["feed_id"]
                         for market in self.markets_by_name

--- a/src/synthetix/pyth/pyth.py
+++ b/src/synthetix/pyth/pyth.py
@@ -1,5 +1,7 @@
 """Module initializing a connection to the Pyth price service."""
 
+import json
+from eth_utils import decode_hex
 import base64
 import requests
 from .constants import PRICE_FEED_IDS
@@ -33,12 +35,153 @@ class Pyth:
 
     def __init__(self, snx, price_service_endpoint: str = None):
         self.snx = snx
+        self.logger = snx.logger
 
         self._price_service_endpoint = price_service_endpoint
         self.price_feed_ids = {}
-        # if snx.network_id in PRICE_FEED_IDS:
-        #     # otherwise use constants
-        #     self.price_feed_ids = PRICE_FEED_IDS[snx.network_id]
+
+    # refactor this class using the following methods
+    # def get_price_from_ids(self, feed_ids: [str])
+    # def get_price_from_symbols(self, symbols: [str])
+    # def get_benchmark_from_ids(self, feed_ids: [str], publish_time: int)
+    # def get_benchmark_from_symbols(self, symbol: str, publish_time: int)
+
+    def update_price_feed_ids(self, feed_ids: dict):
+        """
+        Update the price feed IDs for the Pyth price service.
+        Additionally sets a lookup for feed_id to symbol.
+
+        :param dict feed_ids: Dictionary of feed IDs to update
+        """
+        self.price_feed_ids.update(feed_ids)
+
+        # reverse it and set a lookup from feed_id to symbol
+        self.symbol_lookup = {v: k for k, v in self.price_feed_ids.items()}
+        self.logger.info(f"Symbols: {self.symbol_lookup.keys()}")
+
+    def _fetch_prices(self, feed_ids: [str], publish_time: int | None = None):
+        """
+        Fetch the latest Pyth price data for a list of feed ids. This is the most reliable way to
+        specify the exact feed you want to fetch data for. The feed ids can be found
+        in the Pyth price service documentation, or at a price service API. This function
+        calls the V2 endpoint ``updates/price/latest`` to fetch the data.
+
+        Usage::
+
+            >>> snx.pyth.fetch_latest_price(['0x12345...', '0xabcde...'])
+            [b'...', b'...']
+
+        :param [str] feed_ids: List of feed ids to fetch data for
+        :return: List of price update data
+        :rtype: [bytes] | None
+        """
+        self.logger.info(f"Fetching data for feed ids: {feed_ids}")
+
+        # query endpoint /v2/updates/price/latest
+        params = {"ids[]": feed_ids, "encoding": "hex"}
+        if publish_time is None:
+            # fetch latest data
+            url = f"{self._price_service_endpoint}/v2/updates/price/latest"
+        else:
+            # fetch benchmark data
+            url = f"{self._price_service_endpoint}/v2/updates/price/{publish_time}"
+
+        try:
+            response = requests.get(url, params, timeout=10)
+            if response.status_code != 200:
+                self.logger.error(f"Error fetching latest price data: {response.text}")
+                return None
+
+            response_data = response.json()
+
+            # decode the price data
+            price_update_data = [
+                decode_hex(f"0x{raw_pud}")
+                for raw_pud in response_data["binary"]["data"]
+            ]
+
+            # enrich some metadata
+            meta = {
+                f"0x{feed_data['id']}": {
+                    "symbol": self.symbol_lookup[f"0x{feed_data['id']}"],
+                    "price": int(feed_data["price"]["price"])
+                    * 10 ** feed_data["price"]["expo"],
+                    "publish_time": feed_data["price"]["publish_time"],
+                }
+                for feed_data in response_data["parsed"]
+            }
+
+            return {"price_update_data": price_update_data, "meta": meta}
+        except Exception as err:
+            self.logger.error(f"Error fetching latest price data: {err}")
+            return None
+
+    def get_price_from_ids(self, feed_ids: [str], publish_time: int | None = None):
+        """
+        Fetch the latest Pyth price data for a list of feed ids. This is the most reliable way to
+        specify the exact feed you want to fetch data for. The feed ids can be found
+        in the Pyth price service documentation, or at a price service API. This function
+        calls the V2 endpoint ``updates/price/latest`` to fetch the data.
+
+        Usage::
+
+            >>> snx.pyth.get_price_from_ids(['0x12345...', '0xabcde...'])
+            {
+                "price_update_data": [b'...', b'...'],
+                "meta": {
+                    "0x12345...": {
+                        "symbol": "ETH",
+                        "price": 2000,
+                        "publish_time": 1621203900
+                }
+            }
+
+        :param [str] feed_ids: List of feed ids to fetch data for
+        :return: Dictionary with price update data and metadata
+        :rtype: dict | None
+        """
+        self.logger.info(f"Fetching data for feed ids: {feed_ids}")
+
+        pyth_data = self._fetch_prices(feed_ids, publish_time=publish_time)
+        return pyth_data
+
+    def get_price_from_symbols(self, symbols: [str], publish_time: int | None = None):
+        """
+        Fetch the latest Pyth price data for a list of market symbols. This
+        function is the same as ``get_price_from_ids`` but uses the symbol
+        to fetch the feed id from the lookup table.
+
+        Usage::
+
+            >>> snx.pyth.get_price_from_symbols(['ETH', 'BTC'])
+            {
+                "price_update_data": [b'...', b'...'],
+                "meta": {
+                    "0x12345...": {
+                        "symbol": "ETH",
+                        "price": 2000,
+                        "publish_time": 1621203900
+                }
+            }
+
+        :param [str] symbols: List of symbols to fetch data for
+        :return: Dictionary with price update data and metadata
+        :rtype: dict | None
+        """
+        self.logger.info(f"Fetching data for symbols: {symbols}")
+        # look up all symbols that exist
+        feed_ids = [
+            self.price_feed_ids[symbol]
+            for symbol in symbols
+            if symbol in self.price_feed_ids
+        ]
+        if len(feed_ids) != len(symbols):
+            missing_symbols = set(symbols) - set(self.price_feed_ids.keys())
+            self.logger.error(f"Feed ids not found for symbols: {missing_symbols}")
+            return None
+
+        pyth_data = self._fetch_prices(feed_ids, publish_time=publish_time)
+        return pyth_data
 
     def get_tokens_data(self, tokens: [str]):
         """
@@ -56,7 +199,7 @@ class Pyth:
         :return: List of price update data
         :rtype: [bytes] | None
         """
-        self.snx.logger.info(f"Fetching data for tokens: {tokens}")
+        self.logger.info(f"Fetching data for tokens: {tokens}")
         feed_ids = [self.price_feed_ids[token] for token in tokens]
 
         price_update_data = self.get_feeds_data(feed_ids)
@@ -78,7 +221,7 @@ class Pyth:
         :return: List of price update data
         :rtype: [bytes] | None
         """
-        self.snx.logger.info(f"Fetching data for feed ids: {feed_ids}")
+        self.logger.info(f"Fetching data for feed ids: {feed_ids}")
         url = f"{self._price_service_endpoint}/api/latest_vaas"
         params = {"ids[]": feed_ids}
 
@@ -108,7 +251,7 @@ class Pyth:
         :return: Tuple of price update data, feed id, and publish time
         :rtype: (bytes, str, int) | None
         """
-        self.snx.logger.info(f"Fetching benchmark data for {feed_id} at {publish_time}")
+        self.logger.info(f"Fetching benchmark data for {feed_id} at {publish_time}")
         url = f"{self._price_service_endpoint}/api/get_vaa"
         params = {
             "id": feed_id,
@@ -117,7 +260,7 @@ class Pyth:
 
         try:
             response = requests.get(url, params, timeout=10)
-            self.snx.logger.info(f"Response: {response.json()}")
+            self.logger.info(f"Response: {response.json()}")
 
             # parse the response
             response_data = response.json()
@@ -127,10 +270,10 @@ class Pyth:
 
             return price_update_data, feed_id, publish_time
         except Exception as err:
-            self.snx.logger.error(f"Error fetching benchmark data: {err}")
+            self.logger.error(f"Error fetching benchmark data: {err}")
             return None
 
-    def get_latest_data(self, feed_id: str):
+    def get_price_data(self, feed_id: str):
         """
         Fetch latest Pyth data for a feed id. This method will help
         fetch price data along with metadata, like the publish timestamp. The feed id
@@ -138,14 +281,14 @@ class Pyth:
 
         Usage::
 
-            >>> snx.pyth.get_latest_data('0x12345...')
+            >>> snx.pyth.get_price_data('0x12345...')
             ([b'...'], '0x12345...', 1621203900)
 
         :param [str] feed_ids: A Pyth feed id
         :return: Tuple of price update data, feed id, and publish timestamp
         :rtype: (bytes, str, int) | None
         """
-        self.snx.logger.info(f"Fetching latest data for feed ids: {feed_id}")
+        self.logger.info(f"Fetching latest data for feed ids: {feed_id}")
         url = f"{self._price_service_endpoint}/api/latest_price_feeds"
         params = {"ids[]": [feed_id], "binary": "true"}
 

--- a/src/synthetix/pyth/pyth.py
+++ b/src/synthetix/pyth/pyth.py
@@ -24,8 +24,8 @@ class Pyth:
     The ``Pyth`` class is used to fetch the latest price update data for a list
     of tokens or feed ids::
 
-        price_update_token = snx.pyth.get_tokens_data(['SNX', 'ETH'])
-        price_update_feed = snx.pyth.get_feeds_data(['0x12345...', '0xabcde...'])
+        price_data_symbol = snx.pyth.get_price_from_symbols(['SNX', 'ETH'])
+        price_data_id = snx.pyth.get_price_from_ids(['0x12345...', '0xabcde...'])
 
     :param Synthetix snx: Synthetix class instance
     :param str price_service_endpoint: Pyth price service endpoint
@@ -39,12 +39,7 @@ class Pyth:
 
         self._price_service_endpoint = price_service_endpoint
         self.price_feed_ids = {}
-
-    # refactor this class using the following methods
-    # def get_price_from_ids(self, feed_ids: [str])
-    # def get_price_from_symbols(self, symbols: [str])
-    # def get_benchmark_from_ids(self, feed_ids: [str], publish_time: int)
-    # def get_benchmark_from_symbols(self, symbol: str, publish_time: int)
+        self.symbol_lookup = {}
 
     def update_price_feed_ids(self, feed_ids: dict):
         """
@@ -57,27 +52,22 @@ class Pyth:
 
         # reverse it and set a lookup from feed_id to symbol
         self.symbol_lookup = {v: k for k, v in self.price_feed_ids.items()}
-        self.logger.info(f"Symbols: {self.symbol_lookup.keys()}")
 
     def _fetch_prices(self, feed_ids: [str], publish_time: int | None = None):
         """
-        Fetch the latest Pyth price data for a list of feed ids. This is the most reliable way to
-        specify the exact feed you want to fetch data for. The feed ids can be found
-        in the Pyth price service documentation, or at a price service API. This function
-        calls the V2 endpoint ``updates/price/latest`` to fetch the data.
-
-        Usage::
-
-            >>> snx.pyth.fetch_latest_price(['0x12345...', '0xabcde...'])
-            [b'...', b'...']
+        An internal method for fetching price data from the Pyth price service. This
+        method is used by the public methods ``get_price_from_ids`` and
+        ``get_price_from_symbols``. The method fetches the latest price data for a list
+        of feed ids, deciding which endpoint to use based on the presence of a publish time.
 
         :param [str] feed_ids: List of feed ids to fetch data for
+        :param int publish_time: Publish time for benchmark data
         :return: List of price update data
         :rtype: [bytes] | None
         """
-        self.logger.info(f"Fetching data for feed ids: {feed_ids}")
+        self.logger.info(f"Fetching Pyth data for {len(feed_ids)} markets")
+        self.logger.debug(f"Fetching data for feed ids: {feed_ids}")
 
-        # query endpoint /v2/updates/price/latest
         params = {"ids[]": feed_ids, "encoding": "hex"}
         if publish_time is None:
             # fetch latest data
@@ -103,7 +93,11 @@ class Pyth:
             # enrich some metadata
             meta = {
                 f"0x{feed_data['id']}": {
-                    "symbol": self.symbol_lookup[f"0x{feed_data['id']}"],
+                    "symbol": (
+                        self.symbol_lookup[f"0x{feed_data['id']}"]
+                        if f"0x{feed_data['id']}" in self.symbol_lookup
+                        else "N/A"
+                    ),
                     "price": int(feed_data["price"]["price"])
                     * 10 ** feed_data["price"]["expo"],
                     "publish_time": feed_data["price"]["publish_time"],
@@ -121,7 +115,8 @@ class Pyth:
         Fetch the latest Pyth price data for a list of feed ids. This is the most reliable way to
         specify the exact feed you want to fetch data for. The feed ids can be found
         in the Pyth price service documentation, or at a price service API. This function
-        calls the V2 endpoint ``updates/price/latest`` to fetch the data.
+        calls the V2 endpoint ``updates/price/latest`` to fetch the data. Specify a publish time
+        in order to fetch benchmark data.
 
         Usage::
 
@@ -137,11 +132,10 @@ class Pyth:
             }
 
         :param [str] feed_ids: List of feed ids to fetch data for
+        :param int publish_time: Publish time for benchmark data
         :return: Dictionary with price update data and metadata
         :rtype: dict | None
         """
-        self.logger.info(f"Fetching data for feed ids: {feed_ids}")
-
         pyth_data = self._fetch_prices(feed_ids, publish_time=publish_time)
         return pyth_data
 
@@ -165,10 +159,11 @@ class Pyth:
             }
 
         :param [str] symbols: List of symbols to fetch data for
+        :param int publish_time: Publish time for benchmark data
         :return: Dictionary with price update data and metadata
         :rtype: dict | None
         """
-        self.logger.info(f"Fetching data for symbols: {symbols}")
+        self.logger.debug(f"Fetching data for symbols: {symbols}")
         # look up all symbols that exist
         feed_ids = [
             self.price_feed_ids[symbol]
@@ -182,127 +177,3 @@ class Pyth:
 
         pyth_data = self._fetch_prices(feed_ids, publish_time=publish_time)
         return pyth_data
-
-    def get_tokens_data(self, tokens: [str]):
-        """
-        Fetch the latest Pyth price data for a list of tokens. The tokens must be in the constant
-        file stored at the time the package is built. For a more reliable approach,
-        specify the ``feed_id`` using the ``get_feeds_data`` method.  This function
-        calls the endpoint ``latest_vaas`` to fetch the data.
-
-        Usage::
-
-            >>> snx.pyth.get_tokens_data(['ETH', 'SNX'])
-            [b'...', b'...']
-
-        :param [str] tokens: List of tokens to fetch data for
-        :return: List of price update data
-        :rtype: [bytes] | None
-        """
-        self.logger.info(f"Fetching data for tokens: {tokens}")
-        feed_ids = [self.price_feed_ids[token] for token in tokens]
-
-        price_update_data = self.get_feeds_data(feed_ids)
-        return price_update_data
-
-    def get_feeds_data(self, feed_ids: list):
-        """
-        Fetch the latest Pyth price data for a list of feed ids. This is the most reliable way to
-        specify the exact feed you want to fetch data for. The feed ids can be found
-        in the Pyth price service documentation, or at a price service API. This function
-        calls the endpoint ``latest_vaas`` to fetch the data.
-
-        Usage::
-
-            >>> snx.pyth.get_feeds_data(['0x12345...', '0xabcde...'])
-            [b'...', b'...']
-
-        :param [str] feed_ids: List of feed ids to fetch data for
-        :return: List of price update data
-        :rtype: [bytes] | None
-        """
-        self.logger.info(f"Fetching data for feed ids: {feed_ids}")
-        url = f"{self._price_service_endpoint}/api/latest_vaas"
-        params = {"ids[]": feed_ids}
-
-        try:
-            response = requests.get(url, params, timeout=10)
-            price_update_data = [
-                base64.b64decode(raw_pud) for raw_pud in response.json()
-            ]
-            return price_update_data
-        except Exception as err:
-            print(err)
-            return None
-
-    def get_benchmark_data(self, feed_id: str, publish_time: int):
-        """
-        Fetch benchmark Pyth data for feed id and timestamp. This is the most reliable way to
-        specify the exact feed you want to fetch data for a timestamp in the past. The feed ids can be found
-        in the Pyth price service documentation, or at a price service API. Feed ids are also
-        provided in the revert for ``OracleDataRequired`` errors.
-
-        Usage::
-
-            >>> snx.pyth.get_benchmark_data('0x12345...', 1621203900)
-            ([b'...'], '0x12345...', 1621203900)
-
-        :param str feed_id: A Pyth feed id
-        :return: Tuple of price update data, feed id, and publish time
-        :rtype: (bytes, str, int) | None
-        """
-        self.logger.info(f"Fetching benchmark data for {feed_id} at {publish_time}")
-        url = f"{self._price_service_endpoint}/api/get_vaa"
-        params = {
-            "id": feed_id,
-            "publish_time": publish_time,
-        }
-
-        try:
-            response = requests.get(url, params, timeout=10)
-            self.logger.info(f"Response: {response.json()}")
-
-            # parse the response
-            response_data = response.json()
-
-            price_update_data = base64.b64decode(response_data["vaa"])
-            publish_time = response_data["publishTime"]
-
-            return price_update_data, feed_id, publish_time
-        except Exception as err:
-            self.logger.error(f"Error fetching benchmark data: {err}")
-            return None
-
-    def get_price_data(self, feed_id: str):
-        """
-        Fetch latest Pyth data for a feed id. This method will help
-        fetch price data along with metadata, like the publish timestamp. The feed id
-        can be found in the Pyth price service documentation, or at a price service API.
-
-        Usage::
-
-            >>> snx.pyth.get_price_data('0x12345...')
-            ([b'...'], '0x12345...', 1621203900)
-
-        :param [str] feed_ids: A Pyth feed id
-        :return: Tuple of price update data, feed id, and publish timestamp
-        :rtype: (bytes, str, int) | None
-        """
-        self.logger.info(f"Fetching latest data for feed ids: {feed_id}")
-        url = f"{self._price_service_endpoint}/api/latest_price_feeds"
-        params = {"ids[]": [feed_id], "binary": "true"}
-
-        try:
-            response = requests.get(url, params, timeout=10)
-
-            # parse the response
-            feed_datas = response.json()
-
-            price_update_data = base64.b64decode(feed_data["vaa"])
-            feed_id = base64.b64decode(feed_data["id"])
-            timestamp = feed_data["price"]["publish_time"]
-
-            return price_update_data, feed_id, timestamp
-        except Exception as err:
-            print(err)
-            return None

--- a/src/synthetix/pyth/pyth.py
+++ b/src/synthetix/pyth/pyth.py
@@ -1,4 +1,5 @@
 """Module initializing a connection to the Pyth price service."""
+
 import base64
 import requests
 from .constants import PRICE_FEED_IDS
@@ -34,8 +35,10 @@ class Pyth:
         self.snx = snx
 
         self._price_service_endpoint = price_service_endpoint
-        if snx.network_id in PRICE_FEED_IDS:
-            self.price_feed_ids = PRICE_FEED_IDS[snx.network_id]
+        self.price_feed_ids = {}
+        # if snx.network_id in PRICE_FEED_IDS:
+        #     # otherwise use constants
+        #     self.price_feed_ids = PRICE_FEED_IDS[snx.network_id]
 
     def get_tokens_data(self, tokens: [str]):
         """
@@ -114,6 +117,7 @@ class Pyth:
 
         try:
             response = requests.get(url, params, timeout=10)
+            self.snx.logger.info(f"Response: {response.json()}")
 
             # parse the response
             response_data = response.json()
@@ -123,7 +127,7 @@ class Pyth:
 
             return price_update_data, feed_id, publish_time
         except Exception as err:
-            print(err)
+            self.snx.logger.error(f"Error fetching benchmark data: {err}")
             return None
 
     def get_latest_data(self, feed_id: str):

--- a/src/synthetix/spot/spot.py
+++ b/src/synthetix/spot/spot.py
@@ -389,9 +389,6 @@ class Spot:
         # fix the amount
         amount = 2**256 - 1 if amount is None else ether_to_wei(amount)
         synth_contract = self._get_synth_contract(market_id)
-        tx_data = synth_contract.encodeABI(
-            fn_name="approve", args=[target_address, amount]
-        )
 
         tx_params = self.snx._get_tx_params()
         tx_params = synth_contract.functions.approve(

--- a/src/synthetix/spot/spot.py
+++ b/src/synthetix/spot/spot.py
@@ -39,9 +39,8 @@ class Spot:
     :rtype: Spot
     """
 
-    def __init__(self, snx, pyth):
+    def __init__(self, snx):
         self.snx = snx
-        self.pyth = pyth
         self.logger = snx.logger
 
         # check if spot is deployed on this network

--- a/src/synthetix/synthetix.py
+++ b/src/synthetix/synthetix.py
@@ -243,8 +243,8 @@ class Synthetix:
 
         self.pyth = Pyth(self, price_service_endpoint=price_service_endpoint)
         self.core = Core(self, core_account_id)
-        self.perps = Perps(self, self.pyth, perps_account_id)
-        self.spot = Spot(self, self.pyth)
+        self.spot = Spot(self)
+        self.perps = Perps(self, perps_account_id)
 
     def _load_contracts(self):
         """

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -22,15 +22,15 @@ def network_id(pytestconfig):
 # fixtures
 @pytest.fixture(scope="module")
 def snx(pytestconfig):
-    network_id = pytestconfig.getoption("network_id")
+    network_id = int(pytestconfig.getoption("network_id"))
     rpc_key = f"NETWORK_{network_id}_RPC"
     rpc = os.environ.get(rpc_key)
     address = os.environ.get("ADDRESS")
     if not rpc or not address:
         raise ValueError(f"RPC not specified for network ID {network_id}")
 
-    snx = Synthetix(provider_rpc=rpc, address=address, network_id=network_id)
-    snx.logger.info(f"Using network ID {network_id}")
+    snx = Synthetix(provider_rpc=rpc, address=address)
+    assert snx.network_id == network_id
     return snx
 
 

--- a/src/tests/e2e/base-mainnet/test_base_mainnet_perps.py
+++ b/src/tests/e2e/base-mainnet/test_base_mainnet_perps.py
@@ -53,6 +53,11 @@ def test_perps_markets(snx):
             market in markets_by_name
         ), f"Market {market} is missing in markets_by_name"
 
+        market_summary = markets_by_name[market]
+        assert market_summary["market_name"] == market
+        assert market_summary["index_price"] > 0
+        assert market_summary["feed_id"] is not None
+
 
 def test_perps_account_fetch(snx, logger, account_id):
     """The instance can fetch account ids"""
@@ -179,7 +184,9 @@ def test_account_flow(snx, new_account_id, market_name):
     assert settle_receipt_2["status"] == 1
 
     # check the result
-    position = snx.perps.get_open_position(market_name="ETH", account_id=new_account_id)
+    position = snx.perps.get_open_position(
+        market_name=market_name, account_id=new_account_id
+    )
     assert position["position_size"] == 0
 
     # check the margin and withdraw

--- a/src/tests/pyth/conftest.py
+++ b/src/tests/pyth/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def feed_ids(snx):
+    # check the SDK for feed ids
+    perps_markets = snx.perps.markets_by_name
+    feed_ids = {market: perps_markets[market]["feed_id"] for market in perps_markets}
+
+    # TODO: get backup feeds from the pyth API
+
+    snx.logger.info(f"Feed ids available for: {feed_ids.keys()}")
+    return feed_ids

--- a/src/tests/pyth/test_pyth.py
+++ b/src/tests/pyth/test_pyth.py
@@ -1,7 +1,7 @@
 import time
 
 # constants
-TEST_SYMBOLS = ["ETH", "BTC", "WIF"]
+TEST_SYMBOLS = ["ETH", "BTC", "WIF", "SNX"]
 TEST_LOOKBACK_SECONDS = 60
 
 

--- a/src/tests/pyth/test_pyth.py
+++ b/src/tests/pyth/test_pyth.py
@@ -1,0 +1,86 @@
+import time
+
+# constants
+TEST_SYMBOLS = ["ETH", "BTC", "WIF"]
+TEST_LOOKBACK_SECONDS = 60
+
+
+def test_pyth(snx):
+    assert snx.pyth._price_service_endpoint is not None
+    assert snx.pyth.price_feed_ids is not None
+    assert snx.pyth.symbol_lookup is not None
+
+
+def test_pyth_get_price_from_ids(snx, feed_ids):
+    query_feed_ids = [feed_ids[symbol] for symbol in TEST_SYMBOLS]
+
+    latest_prices = snx.pyth.get_price_from_ids(query_feed_ids)
+    assert latest_prices is not None
+    assert latest_prices["price_update_data"] is not None
+    assert type(latest_prices["meta"]) == dict
+
+    all_symbols = [meta["symbol"] for meta in latest_prices["meta"].values()]
+    assert all([feed_id in latest_prices["meta"] for feed_id in query_feed_ids])
+    assert all([symbol in all_symbols for symbol in TEST_SYMBOLS])
+
+
+def test_pyth_get_price_from_ids_with_timestamp(snx, feed_ids):
+    # get timestamp
+    publish_time = int(time.time()) - TEST_LOOKBACK_SECONDS
+
+    # look up feed ids
+    query_feed_ids = [feed_ids[symbol] for symbol in TEST_SYMBOLS]
+
+    latest_prices = snx.pyth.get_price_from_ids(
+        query_feed_ids, publish_time=publish_time
+    )
+    assert latest_prices is not None
+    assert latest_prices["price_update_data"] is not None
+    assert type(latest_prices["meta"]) == dict
+
+    all_symbols = [meta["symbol"] for meta in latest_prices["meta"].values()]
+    assert all([feed_id in latest_prices["meta"] for feed_id in query_feed_ids])
+    assert all([symbol in all_symbols for symbol in TEST_SYMBOLS])
+
+
+def test_pyth_get_price_from_symbols(snx):
+    # look up feed ids
+    query_feed_ids = [
+        snx.pyth.price_feed_ids[symbol]
+        for symbol in TEST_SYMBOLS
+        if symbol in snx.pyth.price_feed_ids
+    ]
+    assert len(query_feed_ids) == len(TEST_SYMBOLS)
+
+    latest_prices = snx.pyth.get_price_from_symbols(TEST_SYMBOLS)
+    assert latest_prices is not None
+    assert latest_prices["price_update_data"] is not None
+    assert type(latest_prices["meta"]) == dict
+
+    all_symbols = [meta["symbol"] for meta in latest_prices["meta"].values()]
+    assert all([feed_id in latest_prices["meta"] for feed_id in query_feed_ids])
+    assert all([symbol in all_symbols for symbol in TEST_SYMBOLS])
+
+
+def test_pyth_get_price_from_symbols_with_timestamp(snx):
+    # get timestamp
+    publish_time = int(time.time()) - TEST_LOOKBACK_SECONDS
+
+    # look up feed ids
+    query_feed_ids = [
+        snx.pyth.price_feed_ids[symbol]
+        for symbol in TEST_SYMBOLS
+        if symbol in snx.pyth.price_feed_ids
+    ]
+    assert len(query_feed_ids) == len(TEST_SYMBOLS)
+
+    latest_prices = snx.pyth.get_price_from_symbols(
+        TEST_SYMBOLS, publish_time=publish_time
+    )
+    assert latest_prices is not None
+    assert latest_prices["price_update_data"] is not None
+    assert type(latest_prices["meta"]) == dict
+
+    all_symbols = [meta["symbol"] for meta in latest_prices["meta"].values()]
+    assert all([feed_id in latest_prices["meta"] for feed_id in query_feed_ids])
+    assert all([symbol in all_symbols for symbol in TEST_SYMBOLS])


### PR DESCRIPTION
Significant breaking changes to the Pyth integration:
- Deprecates these Pyth functions:
  - `get_tokens_data`
  - `get_feeds_data`
  - `get_benchmark_data`
  - `get_latest_data`

These were replaced with:
  - `get_price_from_ids`
  - `get_price_from_symbols`

The user can choose to provide a publish timestamp, and the functions will dynamically call the benchmark price.

Additional changes:
- Add optimistic price updates to the perps class. This will improve freshness of prices when calling view functions, like pnls.
- Add pyth library integration tests