### PR TITLE
Add market info

### DIFF
--- a/docs/source/guides/advanced_perps.md
+++ b/docs/source/guides/advanced_perps.md
@@ -45,14 +45,16 @@ snx.perps.commit_order(0.1, market_name="BTC", account_id=2, submit=True)
 
 Synthetix perps using a vAMM model, where orders are subject to price impact based on the size of the order. A premium or discount is applied to the index price based on the current skew of the market. For example, if a market is skewed long, there will be a premium applied to the index price, and vice versa.
 
-When placing an order, you can fetch a quote to see the estimated fill price of the order. This fill price is an estimate based on the current index price, current skew, and the size of the order. The quote will also show the estimated margin required for a position of that size.
+When placing an order, you can fetch a quote to see the estimated fill price of the order. This fill price is an estimate based on the current index price, current skew, and the size of the order. The quote will also show exchange and settlement fees, and the estimated margin required for a position of that size.
 ```python
 >>> snx.perps.get_quote(1, market_name="ETH")
 {
     'order_size': 1,
     'index_price': 2995.72,
     'fill_price': 2995.75,
-    'required_margin': 116.49
+    'required_margin': 116.49,
+    'order_fees': 0.11649,
+    'settlement_reward_cost': 1.00137346
 }
 ```
 

--- a/src/tests/test_perps_v3.py
+++ b/src/tests/test_perps_v3.py
@@ -171,20 +171,24 @@ def test_perps_settlement_strategy(snx, logger):
 
 def test_perps_quote(snx):
     """The instance can fetch a quote"""
-    long_quote = snx.perps.get_quote(1, market_id=100)
-    short_quote = snx.perps.get_quote(-1, market_id=100)
+    long_quote = snx.perps.get_quote(1, market_id=TEST_MARKET_ID)
+    short_quote = snx.perps.get_quote(-1, market_id=TEST_MARKET_ID)
 
     assert long_quote is not None
     assert long_quote["order_size"] is not None
     assert long_quote["index_price"] is not None
     assert long_quote["fill_price"] is not None
     assert long_quote["required_margin"] is not None
+    assert long_quote["order_fees"] is not None
+    assert long_quote["settlement_reward_cost"] is not None
 
     assert short_quote is not None
     assert short_quote["order_size"] is not None
     assert short_quote["index_price"] is not None
     assert short_quote["fill_price"] is not None
     assert short_quote["required_margin"] is not None
+    assert short_quote["order_fees"] is not None
+    assert short_quote["settlement_reward_cost"] is not None
 
     # the short fill price should be less than the long fill price
     assert short_quote["fill_price"] < long_quote["fill_price"]
@@ -192,20 +196,24 @@ def test_perps_quote(snx):
 
 def test_perps_quote_with_price(snx):
     """The instance can fetch a quote with a fill price"""
-    long_quote = snx.perps.get_quote(1, price=2500, market_id=100)
-    short_quote = snx.perps.get_quote(-1, price=2500, market_id=100)
+    long_quote = snx.perps.get_quote(1, price=2500, market_id=TEST_MARKET_ID)
+    short_quote = snx.perps.get_quote(-1, price=2500, market_id=TEST_MARKET_ID)
 
     assert long_quote is not None
     assert long_quote["order_size"] is not None
     assert long_quote["index_price"] is not None
     assert long_quote["fill_price"] is not None
     assert long_quote["required_margin"] is not None
+    assert long_quote["order_fees"] is not None
+    assert long_quote["settlement_reward_cost"] is not None
 
     assert short_quote is not None
     assert short_quote["order_size"] is not None
     assert short_quote["index_price"] is not None
     assert short_quote["fill_price"] is not None
     assert short_quote["required_margin"] is not None
+    assert short_quote["order_fees"] is not None
+    assert short_quote["settlement_reward_cost"] is not None
 
     # the short fill price should be less than the long fill price
     assert short_quote["fill_price"] < long_quote["fill_price"]


### PR DESCRIPTION
Add the following to market info:
- maker/taker fees
- skew scale
- max funding velocity
- max market value ($)

Also, update the perps `get_quote` function to include:
- Order fees
- Settlement reward cost
