### PR TITLE
Add request kwargs

### DIFF
--- a/src/synthetix/contracts/contracts.py
+++ b/src/synthetix/contracts/contracts.py
@@ -66,7 +66,7 @@ def load_json_files_from_directory(snx, directory):
 
 
 def get_deployment_hash(snx):
-    provider_rpc = snx.mainnet_rpc
+    provider_rpc = snx.op_mainnet_rpc
     w3 = (
         Web3(Web3.HTTPProvider(provider_rpc))
         if provider_rpc.startswith("http")
@@ -74,7 +74,7 @@ def get_deployment_hash(snx):
     )
 
     deployment_dir = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "deployments", "1"
+        os.path.dirname(os.path.abspath(__file__)), "deployments", "10"
     )
     cannon_file = os.path.join(deployment_dir, "CannonRegistry.json")
     with open(cannon_file, "r") as file:

--- a/src/synthetix/contracts/deployments/10/CannonRegistry.json
+++ b/src/synthetix/contracts/deployments/10/CannonRegistry.json
@@ -1,0 +1,599 @@
+{
+    "address": "0x8E5C7EFC9636A6A0408A46BB7F617094B81e5dba",
+    "abi": [
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "ImplementationIsSterile",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "name",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "InvalidName",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidTags",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "string",
+                    "name": "url",
+                    "type": "string"
+                }
+            ],
+            "name": "InvalidUrl",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "NoChange",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "contr",
+                    "type": "address"
+                }
+            ],
+            "name": "NotAContract",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "addr",
+                    "type": "address"
+                }
+            ],
+            "name": "NotNominated",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "PackageNotFound",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "addr",
+                    "type": "address"
+                }
+            ],
+            "name": "Unauthorized",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "Unauthorized",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "UpgradeSimulationFailed",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "ZeroAddress",
+            "type": "error"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerChanged",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnerNominated",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "name",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "tag",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "variant",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "deployUrl",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "metaUrl",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "PackagePublish",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "name",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "verifier",
+                    "type": "address"
+                }
+            ],
+            "name": "PackageUnverify",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "name",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "verifier",
+                    "type": "address"
+                }
+            ],
+            "name": "PackageVerify",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "self",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "Upgraded",
+            "type": "event"
+        },
+        {
+            "inputs": [],
+            "name": "MIN_PACKAGE_NAME_LENGTH",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "acceptOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "acceptPackageOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getAdditionalDeployers",
+            "outputs": [
+                {
+                    "internalType": "address[]",
+                    "name": "additionalDeployers",
+                    "type": "address[]"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "getImplementation",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageVersionName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageVariant",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getPackageMeta",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getPackageNominatedOwner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getPackageOwner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageVersionName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageVariant",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getPackageUrl",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes[]",
+                    "name": "data",
+                    "type": "bytes[]"
+                }
+            ],
+            "name": "multicall",
+            "outputs": [
+                {
+                    "internalType": "bytes[]",
+                    "name": "results",
+                    "type": "bytes[]"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newNominatedOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "nominateNewOwner",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "address",
+                    "name": "_newPackageOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "nominatePackageOwner",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "nominatedOwner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "owner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "_variant",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32[]",
+                    "name": "_packageTags",
+                    "type": "bytes32[]"
+                },
+                {
+                    "internalType": "string",
+                    "name": "_packageDeployUrl",
+                    "type": "string"
+                },
+                {
+                    "internalType": "string",
+                    "name": "_packageMetaUrl",
+                    "type": "string"
+                }
+            ],
+            "name": "publish",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "renounceNomination",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "address[]",
+                    "name": "additionalDeployers",
+                    "type": "address[]"
+                }
+            ],
+            "name": "setAdditionalDeployers",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newImplementation",
+                    "type": "address"
+                }
+            ],
+            "name": "simulateUpgradeTo",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "unverifyPackage",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_newImplementation",
+                    "type": "address"
+                }
+            ],
+            "name": "upgradeTo",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_name",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "validatePackageName",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "_packageName",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "verifyPackage",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        }
+    ]
+}

--- a/src/synthetix/contracts/deployments/42161/ARB.json
+++ b/src/synthetix/contracts/deployments/42161/ARB.json
@@ -1,0 +1,854 @@
+{
+    "address": "0x912CE59144191C1204E64559FE8253a0e49E6548",
+    "abi": [
+        {
+            "inputs": [],
+            "stateMutability": "nonpayable",
+            "type": "constructor"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "delegator",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "fromDelegate",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "toDelegate",
+                    "type": "address"
+                }
+            ],
+            "name": "DelegateChanged",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "delegate",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "previousBalance",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBalance",
+                    "type": "uint256"
+                }
+            ],
+            "name": "DelegateVotesChanged",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "version",
+                    "type": "uint8"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        {
+            "inputs": [],
+            "name": "DOMAIN_SEPARATOR",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "MINT_CAP_DENOMINATOR",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "MINT_CAP_NUMERATOR",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "MIN_MINT_INTERVAL",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                }
+            ],
+            "name": "allowance",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "approve",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "balanceOf",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "burn",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "burnFrom",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint32",
+                    "name": "pos",
+                    "type": "uint32"
+                }
+            ],
+            "name": "checkpoints",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint32",
+                            "name": "fromBlock",
+                            "type": "uint32"
+                        },
+                        {
+                            "internalType": "uint224",
+                            "name": "votes",
+                            "type": "uint224"
+                        }
+                    ],
+                    "internalType": "struct ERC20VotesUpgradeable.Checkpoint",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "decimals",
+            "outputs": [
+                {
+                    "internalType": "uint8",
+                    "name": "",
+                    "type": "uint8"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "subtractedValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "decreaseAllowance",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "delegatee",
+                    "type": "address"
+                }
+            ],
+            "name": "delegate",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "delegatee",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "nonce",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "expiry",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "v",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "r",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "s",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "delegateBySig",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "delegates",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "blockNumber",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getPastTotalSupply",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "blockNumber",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getPastVotes",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "getVotes",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "addedValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "increaseAllowance",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_l1TokenAddress",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_initialSupply",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address",
+                    "name": "_owner",
+                    "type": "address"
+                }
+            ],
+            "name": "initialize",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "l1Address",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "mint",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "name",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "nextMint",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "nonces",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "numCheckpoints",
+            "outputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "",
+                    "type": "uint32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "owner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "deadline",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "v",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "r",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "s",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "permit",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "renounceOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "symbol",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "totalSupply",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transfer",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_value",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "_data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "transferAndCall",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "success",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferFrom",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "transferOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        }
+    ]
+}

--- a/src/synthetix/contracts/deployments/42161/Pyth.json
+++ b/src/synthetix/contracts/deployments/42161/Pyth.json
@@ -1,0 +1,1632 @@
+{
+    "address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+    "abi": [
+        {
+            "inputs": [],
+            "stateMutability": "nonpayable",
+            "type": "constructor"
+        },
+        {
+            "inputs": [],
+            "name": "InsufficientFee",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidArgument",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidGovernanceDataSource",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidGovernanceMessage",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidGovernanceTarget",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidUpdateData",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidUpdateDataSource",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidWormholeAddressToSet",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "InvalidWormholeVaa",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "NoFreshUpdate",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "OldGovernanceMessage",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "PriceFeedNotFound",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "PriceFeedNotFoundWithinRange",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "StalePrice",
+            "type": "error"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "previousAdmin",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newAdmin",
+                    "type": "address"
+                }
+            ],
+            "name": "AdminChanged",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint16",
+                    "name": "chainId",
+                    "type": "uint16"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "sequenceNumber",
+                    "type": "uint64"
+                }
+            ],
+            "name": "BatchPriceFeedUpdate",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "beacon",
+                    "type": "address"
+                }
+            ],
+            "name": "BeaconUpgraded",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldImplementation",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newImplementation",
+                    "type": "address"
+                }
+            ],
+            "name": "ContractUpgraded",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct PythInternalStructs.DataSource[]",
+                    "name": "oldDataSources",
+                    "type": "tuple[]"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct PythInternalStructs.DataSource[]",
+                    "name": "newDataSources",
+                    "type": "tuple[]"
+                }
+            ],
+            "name": "DataSourcesSet",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldFee",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newFee",
+                    "type": "uint256"
+                }
+            ],
+            "name": "FeeSet",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct PythInternalStructs.DataSource",
+                    "name": "oldDataSource",
+                    "type": "tuple"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "indexed": false,
+                    "internalType": "struct PythInternalStructs.DataSource",
+                    "name": "newDataSource",
+                    "type": "tuple"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "initialSequence",
+                    "type": "uint64"
+                }
+            ],
+            "name": "GovernanceDataSourceSet",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "version",
+                    "type": "uint8"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "publishTime",
+                    "type": "uint64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "int64",
+                    "name": "price",
+                    "type": "int64"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint64",
+                    "name": "conf",
+                    "type": "uint64"
+                }
+            ],
+            "name": "PriceFeedUpdate",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "implementation",
+                    "type": "address"
+                }
+            ],
+            "name": "Upgraded",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "oldValidPeriod",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newValidPeriod",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ValidPeriodSet",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "oldWormholeAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newWormholeAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "WormholeAddressSet",
+            "type": "event"
+        },
+        {
+            "inputs": [],
+            "name": "chainId",
+            "outputs": [
+                {
+                    "internalType": "uint16",
+                    "name": "",
+                    "type": "uint16"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "encodedVM",
+                    "type": "bytes"
+                }
+            ],
+            "name": "executeGovernanceInstruction",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "id",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getEmaPrice",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "int64",
+                            "name": "price",
+                            "type": "int64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "conf",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "int32",
+                            "name": "expo",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "publishTime",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct PythStructs.Price",
+                    "name": "price",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "age",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getEmaPriceNoOlderThan",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "int64",
+                            "name": "price",
+                            "type": "int64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "conf",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "int32",
+                            "name": "expo",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "publishTime",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct PythStructs.Price",
+                    "name": "price",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "id",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getEmaPriceUnsafe",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "int64",
+                            "name": "price",
+                            "type": "int64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "conf",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "int32",
+                            "name": "expo",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "publishTime",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct PythStructs.Price",
+                    "name": "price",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "id",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getPrice",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "int64",
+                            "name": "price",
+                            "type": "int64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "conf",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "int32",
+                            "name": "expo",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "publishTime",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct PythStructs.Price",
+                    "name": "price",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "id",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "age",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getPriceNoOlderThan",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "int64",
+                            "name": "price",
+                            "type": "int64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "conf",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "int32",
+                            "name": "expo",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "publishTime",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct PythStructs.Price",
+                    "name": "price",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "id",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "getPriceUnsafe",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "int64",
+                            "name": "price",
+                            "type": "int64"
+                        },
+                        {
+                            "internalType": "uint64",
+                            "name": "conf",
+                            "type": "uint64"
+                        },
+                        {
+                            "internalType": "int32",
+                            "name": "expo",
+                            "type": "int32"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "publishTime",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct PythStructs.Price",
+                    "name": "price",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes[]",
+                    "name": "updateData",
+                    "type": "bytes[]"
+                }
+            ],
+            "name": "getUpdateFee",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "feeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "updateDataSize",
+                    "type": "uint256"
+                }
+            ],
+            "name": "getUpdateFee",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "feeAmount",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "getValidTimePeriod",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "governanceDataSource",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct PythInternalStructs.DataSource",
+                    "name": "",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "governanceDataSourceIndex",
+            "outputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "",
+                    "type": "uint32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct PythInternalStructs.DataSource",
+                    "name": "ds",
+                    "type": "tuple"
+                }
+            ],
+            "name": "hashDataSource",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "wormhole",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint16[]",
+                    "name": "dataSourceEmitterChainIds",
+                    "type": "uint16[]"
+                },
+                {
+                    "internalType": "bytes32[]",
+                    "name": "dataSourceEmitterAddresses",
+                    "type": "bytes32[]"
+                },
+                {
+                    "internalType": "uint16",
+                    "name": "governanceEmitterChainId",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "governanceEmitterAddress",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "uint64",
+                    "name": "governanceInitialSequence",
+                    "type": "uint64"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "validTimePeriodSeconds",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "singleUpdateFeeInWei",
+                    "type": "uint256"
+                }
+            ],
+            "name": "initialize",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint16",
+                    "name": "dataSourceChainId",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "dataSourceEmitterAddress",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "isValidDataSource",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint16",
+                    "name": "governanceChainId",
+                    "type": "uint16"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "governanceEmitterAddress",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "isValidGovernanceDataSource",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "lastExecutedGovernanceSequence",
+            "outputs": [
+                {
+                    "internalType": "uint64",
+                    "name": "",
+                    "type": "uint64"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "priceId",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "latestPriceInfoPublishTime",
+            "outputs": [
+                {
+                    "internalType": "uint64",
+                    "name": "",
+                    "type": "uint64"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "owner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "encodedPayload",
+                    "type": "bytes"
+                }
+            ],
+            "name": "parseAuthorizeGovernanceDataSourceTransferPayload",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes",
+                            "name": "claimVaa",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct PythGovernanceInstructions.AuthorizeGovernanceDataSourceTransferPayload",
+                    "name": "sgds",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "encodedInstruction",
+                    "type": "bytes"
+                }
+            ],
+            "name": "parseGovernanceInstruction",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "enum PythGovernanceInstructions.GovernanceModule",
+                            "name": "module",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "enum PythGovernanceInstructions.GovernanceAction",
+                            "name": "action",
+                            "type": "uint8"
+                        },
+                        {
+                            "internalType": "uint16",
+                            "name": "targetChainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "payload",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct PythGovernanceInstructions.GovernanceInstruction",
+                    "name": "gi",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes[]",
+                    "name": "updateData",
+                    "type": "bytes[]"
+                },
+                {
+                    "internalType": "bytes32[]",
+                    "name": "priceIds",
+                    "type": "bytes32[]"
+                },
+                {
+                    "internalType": "uint64",
+                    "name": "minPublishTime",
+                    "type": "uint64"
+                },
+                {
+                    "internalType": "uint64",
+                    "name": "maxPublishTime",
+                    "type": "uint64"
+                }
+            ],
+            "name": "parsePriceFeedUpdates",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "id",
+                            "type": "bytes32"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "int64",
+                                    "name": "price",
+                                    "type": "int64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "conf",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "int32",
+                                    "name": "expo",
+                                    "type": "int32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "publishTime",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct PythStructs.Price",
+                            "name": "price",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "int64",
+                                    "name": "price",
+                                    "type": "int64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "conf",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "int32",
+                                    "name": "expo",
+                                    "type": "int32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "publishTime",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct PythStructs.Price",
+                            "name": "emaPrice",
+                            "type": "tuple"
+                        }
+                    ],
+                    "internalType": "struct PythStructs.PriceFeed[]",
+                    "name": "priceFeeds",
+                    "type": "tuple[]"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes[]",
+                    "name": "updateData",
+                    "type": "bytes[]"
+                },
+                {
+                    "internalType": "bytes32[]",
+                    "name": "priceIds",
+                    "type": "bytes32[]"
+                },
+                {
+                    "internalType": "uint64",
+                    "name": "minPublishTime",
+                    "type": "uint64"
+                },
+                {
+                    "internalType": "uint64",
+                    "name": "maxPublishTime",
+                    "type": "uint64"
+                }
+            ],
+            "name": "parsePriceFeedUpdatesUnique",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "id",
+                            "type": "bytes32"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "int64",
+                                    "name": "price",
+                                    "type": "int64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "conf",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "int32",
+                                    "name": "expo",
+                                    "type": "int32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "publishTime",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct PythStructs.Price",
+                            "name": "price",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "int64",
+                                    "name": "price",
+                                    "type": "int64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "conf",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "int32",
+                                    "name": "expo",
+                                    "type": "int32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "publishTime",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct PythStructs.Price",
+                            "name": "emaPrice",
+                            "type": "tuple"
+                        }
+                    ],
+                    "internalType": "struct PythStructs.PriceFeed[]",
+                    "name": "priceFeeds",
+                    "type": "tuple[]"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "encodedPayload",
+                    "type": "bytes"
+                }
+            ],
+            "name": "parseRequestGovernanceDataSourceTransferPayload",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint32",
+                            "name": "governanceDataSourceIndex",
+                            "type": "uint32"
+                        }
+                    ],
+                    "internalType": "struct PythGovernanceInstructions.RequestGovernanceDataSourceTransferPayload",
+                    "name": "sgdsClaim",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "encodedPayload",
+                    "type": "bytes"
+                }
+            ],
+            "name": "parseSetDataSourcesPayload",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "uint16",
+                                    "name": "chainId",
+                                    "type": "uint16"
+                                },
+                                {
+                                    "internalType": "bytes32",
+                                    "name": "emitterAddress",
+                                    "type": "bytes32"
+                                }
+                            ],
+                            "internalType": "struct PythInternalStructs.DataSource[]",
+                            "name": "dataSources",
+                            "type": "tuple[]"
+                        }
+                    ],
+                    "internalType": "struct PythGovernanceInstructions.SetDataSourcesPayload",
+                    "name": "sds",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "encodedPayload",
+                    "type": "bytes"
+                }
+            ],
+            "name": "parseSetFeePayload",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "newFee",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct PythGovernanceInstructions.SetFeePayload",
+                    "name": "sf",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "encodedPayload",
+                    "type": "bytes"
+                }
+            ],
+            "name": "parseSetValidPeriodPayload",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint256",
+                            "name": "newValidPeriod",
+                            "type": "uint256"
+                        }
+                    ],
+                    "internalType": "struct PythGovernanceInstructions.SetValidPeriodPayload",
+                    "name": "svp",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "encodedPayload",
+                    "type": "bytes"
+                }
+            ],
+            "name": "parseSetWormholeAddressPayload",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "newWormholeAddress",
+                            "type": "address"
+                        }
+                    ],
+                    "internalType": "struct PythGovernanceInstructions.SetWormholeAddressPayload",
+                    "name": "sw",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes",
+                    "name": "encodedPayload",
+                    "type": "bytes"
+                }
+            ],
+            "name": "parseUpgradeContractPayload",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "newImplementation",
+                            "type": "address"
+                        }
+                    ],
+                    "internalType": "struct PythGovernanceInstructions.UpgradeContractPayload",
+                    "name": "uc",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "id",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "priceFeedExists",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "proxiableUUID",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "pythUpgradableMagic",
+            "outputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "",
+                    "type": "uint32"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "id",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "queryPriceFeed",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "id",
+                            "type": "bytes32"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "int64",
+                                    "name": "price",
+                                    "type": "int64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "conf",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "int32",
+                                    "name": "expo",
+                                    "type": "int32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "publishTime",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct PythStructs.Price",
+                            "name": "price",
+                            "type": "tuple"
+                        },
+                        {
+                            "components": [
+                                {
+                                    "internalType": "int64",
+                                    "name": "price",
+                                    "type": "int64"
+                                },
+                                {
+                                    "internalType": "uint64",
+                                    "name": "conf",
+                                    "type": "uint64"
+                                },
+                                {
+                                    "internalType": "int32",
+                                    "name": "expo",
+                                    "type": "int32"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "publishTime",
+                                    "type": "uint256"
+                                }
+                            ],
+                            "internalType": "struct PythStructs.Price",
+                            "name": "emaPrice",
+                            "type": "tuple"
+                        }
+                    ],
+                    "internalType": "struct PythStructs.PriceFeed",
+                    "name": "priceFeed",
+                    "type": "tuple"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "renounceOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "singleUpdateFeeInWei",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "transferOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes[]",
+                    "name": "updateData",
+                    "type": "bytes[]"
+                }
+            ],
+            "name": "updatePriceFeeds",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "bytes[]",
+                    "name": "updateData",
+                    "type": "bytes[]"
+                },
+                {
+                    "internalType": "bytes32[]",
+                    "name": "priceIds",
+                    "type": "bytes32[]"
+                },
+                {
+                    "internalType": "uint64[]",
+                    "name": "publishTimes",
+                    "type": "uint64[]"
+                }
+            ],
+            "name": "updatePriceFeedsIfNecessary",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newImplementation",
+                    "type": "address"
+                }
+            ],
+            "name": "upgradeTo",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newImplementation",
+                    "type": "address"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "upgradeToAndCall",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "validDataSources",
+            "outputs": [
+                {
+                    "components": [
+                        {
+                            "internalType": "uint16",
+                            "name": "chainId",
+                            "type": "uint16"
+                        },
+                        {
+                            "internalType": "bytes32",
+                            "name": "emitterAddress",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "internalType": "struct PythInternalStructs.DataSource[]",
+                    "name": "",
+                    "type": "tuple[]"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "validTimePeriodSeconds",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "version",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "wormhole",
+            "outputs": [
+                {
+                    "internalType": "contract IWormhole",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        }
+    ]
+}

--- a/src/synthetix/contracts/deployments/42161/USDC.json
+++ b/src/synthetix/contracts/deployments/42161/USDC.json
@@ -1,0 +1,1231 @@
+{
+    "address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+    "abi": [
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "authorizer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "nonce",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "AuthorizationCanceled",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "authorizer",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "bytes32",
+                    "name": "nonce",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "AuthorizationUsed",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_account",
+                    "type": "address"
+                }
+            ],
+            "name": "Blacklisted",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newBlacklister",
+                    "type": "address"
+                }
+            ],
+            "name": "BlacklisterChanged",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "burner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Burn",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newMasterMinter",
+                    "type": "address"
+                }
+            ],
+            "name": "MasterMinterChanged",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Mint",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "minterAllowedAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "MinterConfigured",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "oldMinter",
+                    "type": "address"
+                }
+            ],
+            "name": "MinterRemoved",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Pause",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "PauserChanged",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newRescuer",
+                    "type": "address"
+                }
+            ],
+            "name": "RescuerChanged",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "_account",
+                    "type": "address"
+                }
+            ],
+            "name": "UnBlacklisted",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [],
+            "name": "Unpause",
+            "type": "event"
+        },
+        {
+            "inputs": [],
+            "name": "CANCEL_AUTHORIZATION_TYPEHASH",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "DOMAIN_SEPARATOR",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "PERMIT_TYPEHASH",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "RECEIVE_WITH_AUTHORIZATION_TYPEHASH",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "TRANSFER_WITH_AUTHORIZATION_TYPEHASH",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                }
+            ],
+            "name": "allowance",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "approve",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "authorizer",
+                    "type": "address"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "nonce",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "authorizationState",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "balanceOf",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_account",
+                    "type": "address"
+                }
+            ],
+            "name": "blacklist",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "blacklister",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "burn",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "authorizer",
+                    "type": "address"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "nonce",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "v",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "r",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "s",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "cancelAuthorization",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "minter",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "minterAllowedAmount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "configureMinter",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "currency",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "decimals",
+            "outputs": [
+                {
+                    "internalType": "uint8",
+                    "name": "",
+                    "type": "uint8"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "decrement",
+                    "type": "uint256"
+                }
+            ],
+            "name": "decreaseAllowance",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "increment",
+                    "type": "uint256"
+                }
+            ],
+            "name": "increaseAllowance",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "string",
+                    "name": "tokenName",
+                    "type": "string"
+                },
+                {
+                    "internalType": "string",
+                    "name": "tokenSymbol",
+                    "type": "string"
+                },
+                {
+                    "internalType": "string",
+                    "name": "tokenCurrency",
+                    "type": "string"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "tokenDecimals",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "address",
+                    "name": "newMasterMinter",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "newPauser",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "newBlacklister",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "initialize",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "string",
+                    "name": "newName",
+                    "type": "string"
+                }
+            ],
+            "name": "initializeV2",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "lostAndFound",
+                    "type": "address"
+                }
+            ],
+            "name": "initializeV2_1",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_account",
+                    "type": "address"
+                }
+            ],
+            "name": "isBlacklisted",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "isMinter",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "masterMinter",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "mint",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "minter",
+                    "type": "address"
+                }
+            ],
+            "name": "minterAllowance",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "name",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "nonces",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "owner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "pause",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "paused",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "pauser",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "deadline",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "v",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "r",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "s",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "permit",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "validAfter",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "validBefore",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "nonce",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "v",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "r",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "s",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "receiveWithAuthorization",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "minter",
+                    "type": "address"
+                }
+            ],
+            "name": "removeMinter",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "contract IERC20",
+                    "name": "tokenContract",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "rescueERC20",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "rescuer",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "symbol",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "totalSupply",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transfer",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferFrom",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "transferOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "validAfter",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "validBefore",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "nonce",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "v",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "r",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "s",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "transferWithAuthorization",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_account",
+                    "type": "address"
+                }
+            ],
+            "name": "unBlacklist",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "unpause",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_newBlacklister",
+                    "type": "address"
+                }
+            ],
+            "name": "updateBlacklister",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_newMasterMinter",
+                    "type": "address"
+                }
+            ],
+            "name": "updateMasterMinter",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_newPauser",
+                    "type": "address"
+                }
+            ],
+            "name": "updatePauser",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newRescuer",
+                    "type": "address"
+                }
+            ],
+            "name": "updateRescuer",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "version",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        }
+    ]
+}

--- a/src/synthetix/contracts/deployments/42161/WETH.json
+++ b/src/synthetix/contracts/deployments/42161/WETH.json
@@ -1,0 +1,560 @@
+{
+    "address": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+    "abi": [
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        {
+            "inputs": [],
+            "name": "DOMAIN_SEPARATOR",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                }
+            ],
+            "name": "allowance",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "approve",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "balanceOf",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "bridgeBurn",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "bridgeMint",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "decimals",
+            "outputs": [
+                {
+                    "internalType": "uint8",
+                    "name": "",
+                    "type": "uint8"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "subtractedValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "decreaseAllowance",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "deposit",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "depositTo",
+            "outputs": [],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "addedValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "increaseAllowance",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "string",
+                    "name": "_name",
+                    "type": "string"
+                },
+                {
+                    "internalType": "string",
+                    "name": "_symbol",
+                    "type": "string"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "_decimals",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "address",
+                    "name": "_l2Gateway",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "_l1Address",
+                    "type": "address"
+                }
+            ],
+            "name": "initialize",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "l1Address",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "l2Gateway",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "name",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "nonces",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "deadline",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "v",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "r",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "s",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "permit",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "symbol",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "totalSupply",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transfer",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_value",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "_data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "transferAndCall",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "success",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferFrom",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "withdraw",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "withdrawTo",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "stateMutability": "payable",
+            "type": "receive"
+        }
+    ]
+}

--- a/src/synthetix/contracts/deployments/84532/ERC4626.json
+++ b/src/synthetix/contracts/deployments/84532/ERC4626.json
@@ -1,0 +1,851 @@
+{
+    "address": "",
+    "abi": [
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "asset",
+                    "type": "address"
+                },
+                {
+                    "internalType": "string",
+                    "name": "vaultName",
+                    "type": "string"
+                },
+                {
+                    "internalType": "string",
+                    "name": "vaultSymbol",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "constructor"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "target",
+                    "type": "address"
+                }
+            ],
+            "name": "AddressEmptyCode",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "allowance",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "needed",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC20InsufficientAllowance",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "balance",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "needed",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC20InsufficientBalance",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "approver",
+                    "type": "address"
+                }
+            ],
+            "name": "ERC20InvalidApprover",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "receiver",
+                    "type": "address"
+                }
+            ],
+            "name": "ERC20InvalidReceiver",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                }
+            ],
+            "name": "ERC20InvalidSender",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                }
+            ],
+            "name": "ERC20InvalidSpender",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "receiver",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "assets",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "max",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC4626ExceededMaxDeposit",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "receiver",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "shares",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "max",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC4626ExceededMaxMint",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "shares",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "max",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC4626ExceededMaxRedeem",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "assets",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "max",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ERC4626ExceededMaxWithdraw",
+            "type": "error"
+        },
+        {
+            "inputs": [],
+            "name": "FailedCall",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "balance",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "needed",
+                    "type": "uint256"
+                }
+            ],
+            "name": "InsufficientBalance",
+            "type": "error"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                }
+            ],
+            "name": "SafeERC20FailedOperation",
+            "type": "error"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "assets",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "shares",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Deposit",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "sender",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "receiver",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "assets",
+                    "type": "uint256"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "shares",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Withdraw",
+            "type": "event"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                }
+            ],
+            "name": "allowance",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "approve",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "asset",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "balanceOf",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "shares",
+                    "type": "uint256"
+                }
+            ],
+            "name": "convertToAssets",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "assets",
+                    "type": "uint256"
+                }
+            ],
+            "name": "convertToShares",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "decimals",
+            "outputs": [
+                {
+                    "internalType": "uint8",
+                    "name": "",
+                    "type": "uint8"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "assets",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address",
+                    "name": "receiver",
+                    "type": "address"
+                }
+            ],
+            "name": "deposit",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "maxDeposit",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "maxMint",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "maxRedeem",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "maxWithdraw",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "shares",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address",
+                    "name": "receiver",
+                    "type": "address"
+                }
+            ],
+            "name": "mint",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "name",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "assets",
+                    "type": "uint256"
+                }
+            ],
+            "name": "previewDeposit",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "shares",
+                    "type": "uint256"
+                }
+            ],
+            "name": "previewMint",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "shares",
+                    "type": "uint256"
+                }
+            ],
+            "name": "previewRedeem",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "assets",
+                    "type": "uint256"
+                }
+            ],
+            "name": "previewWithdraw",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "shares",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address",
+                    "name": "receiver",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "redeem",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "symbol",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "totalAssets",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "totalSupply",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transfer",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferFrom",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "assets",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "address",
+                    "name": "receiver",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "withdraw",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        }
+    ]
+}

--- a/src/synthetix/spot/spot.py
+++ b/src/synthetix/spot/spot.py
@@ -119,7 +119,10 @@ class Spot:
         market_id, market_name = self._resolve_market(market_id, None)
 
         # hard-coding a catch for USDC with 6 decimals
-        if self.snx.network_id in [8453, 84532, 421614] and market_name in "sUSDC":
+        if self.snx.network_id in [8453, 84532, 421614, 42161] and market_name in [
+            "sUSDC",
+            "sStataUSDC",
+        ]:
             size_wei = format_ether(size, decimals=6)
         else:
             size_wei = format_ether(size)
@@ -211,9 +214,9 @@ class Spot:
                 "contract": synth_contract,
             }
             if market_id in settlement_strategies:
-                markets_by_id[market_id][
-                    "settlement_strategy"
-                ] = settlement_strategies[market_id]
+                markets_by_id[market_id]["settlement_strategy"] = settlement_strategies[
+                    market_id
+                ]
 
         # update pyth price feed ids
         update_feeds = {

--- a/src/synthetix/synthetix.py
+++ b/src/synthetix/synthetix.py
@@ -145,6 +145,7 @@ class Synthetix:
         pyth_cache_ttl: int = 60,
         gas_multiplier: float = DEFAULT_GAS_MULTIPLIER,
         is_fork: bool = False,
+        request_kwargs: dict = {},
     ):
         args = parse_args()
         self.logger = setup_logging(args.debug, args.verbose)
@@ -164,7 +165,7 @@ class Synthetix:
 
         # init chain provider
         if provider_rpc.startswith("http"):
-            web3 = Web3(Web3.HTTPProvider(self.provider_rpc))
+            web3 = Web3(Web3.HTTPProvider(self.provider_rpc, request_kwargs=request_kwargs))
         elif provider_rpc.startswith("wss"):
             web3 = Web3(Web3.WebsocketProvider(self.provider_rpc))
         elif provider_rpc.endswith("ipc"):

--- a/src/synthetix/synthetix.py
+++ b/src/synthetix/synthetix.py
@@ -87,7 +87,7 @@ class Synthetix:
 
     :param str provider_rpc: An RPC endpoint to use for the provider that interacts
         with the smart contracts. This must match the ``network_id``.
-    :param str mainnet_rpc: A mainnet RPC endpoint to use for the provider that
+    :param str op_mainnet_rpc: An Optimism mainnet RPC endpoint to use for the provider that
         fetches deployments from the Cannon registry.
     :param str ipfs_gateway: An IPFS gateway to use for fetching deployments from Cannon.
     :param str address: Wallet address to use as a default. If a private key is
@@ -126,7 +126,7 @@ class Synthetix:
     def __init__(
         self,
         provider_rpc: str,
-        mainnet_rpc: str = "https://eth.llamarpc.com",
+        op_mainnet_rpc: str = "https://optimism.llamarpc.com",
         ipfs_gateway: str = "https://ipfs.synthetix.io/ipfs/",
         address: str = ADDRESS_ZERO,
         private_key: str = None,
@@ -155,7 +155,7 @@ class Synthetix:
         self.use_estimate_gas = use_estimate_gas
         self.cannon_config = cannon_config
         self.provider_rpc = provider_rpc
-        self.mainnet_rpc = mainnet_rpc
+        self.op_mainnet_rpc = op_mainnet_rpc
         self.ipfs_gateway = ipfs_gateway
         self.gas_multiplier = gas_multiplier
         self.max_price_impact = max_price_impact
@@ -165,7 +165,9 @@ class Synthetix:
 
         # init chain provider
         if provider_rpc.startswith("http"):
-            web3 = Web3(Web3.HTTPProvider(self.provider_rpc, request_kwargs=request_kwargs))
+            web3 = Web3(
+                Web3.HTTPProvider(self.provider_rpc, request_kwargs=request_kwargs)
+            )
         elif provider_rpc.startswith("wss"):
             web3 = Web3(Web3.WebsocketProvider(self.provider_rpc))
         elif provider_rpc.endswith("ipc"):

--- a/src/tests/e2e/arbitrum-mainnet-fork/conftest.py
+++ b/src/tests/e2e/arbitrum-mainnet-fork/conftest.py
@@ -12,7 +12,8 @@ RPC = os.environ.get("LOCAL_RPC")
 OP_MAINNET_RPC = os.environ.get("NETWORK_10_RPC")
 
 SNX_DEPLOYER_ADDRESS = "0x48914229deDd5A9922f44441ffCCfC2Cb7856Ee9"
-USDC_WHALE = "0x09eF1E9AA278C4A234a897c736fa933E9B2617a7"
+USDC_WHALE = "0xB38e8c17e38363aF6EbdCb3dAE12e0243582891D"
+ARB_WHALE = "0xB38e8c17e38363aF6EbdCb3dAE12e0243582891D"
 
 
 # fixtures
@@ -22,11 +23,6 @@ def snx(pytestconfig):
     snx = Synthetix(
         provider_rpc=RPC,
         op_mainnet_rpc=OP_MAINNET_RPC,
-        cannon_config={
-            "package": "synthetix-omnibus",
-            "version": "latest",
-            "preset": "main",
-        },
     )
 
     return snx
@@ -36,83 +32,47 @@ def snx(pytestconfig):
 def contracts(snx):
     # create some needed contracts
     weth = snx.contracts["WETH"]["contract"]
-
-    dai = snx.web3.eth.contract(
-        address=snx.contracts["packages"]["dai_mock_collateral"]["MintableToken"][
-            "address"
-        ],
-        abi=snx.contracts["packages"]["dai_mock_collateral"]["MintableToken"]["abi"],
-    )
-
     usdc = snx.contracts["USDC"]["contract"]
-
-    arb = snx.web3.eth.contract(
-        address=snx.contracts["packages"]["arb_mock_collateral"]["MintableToken"][
-            "address"
-        ],
-        abi=snx.contracts["packages"]["arb_mock_collateral"]["MintableToken"]["abi"],
-    )
-
+    arb = snx.contracts["ARB"]["contract"]
     return {
         "WETH": weth,
-        "DAI": dai,
         "USDC": usdc,
         "ARB": arb,
     }
 
 
 @pytest.fixture(scope="module")
-def mint_dai(snx, contracts):
-    """The instance can mint DAI tokens"""
-    snx.web3.provider.make_request("anvil_impersonateAccount", [SNX_DEPLOYER_ADDRESS])
+def steal_arb(snx, contracts):
+    """The instance can steal ARB tokens"""
+    # check arb balance
+    arb_contract = contracts["ARB"]
+    arb_balance = arb_contract.functions.balanceOf(snx.address).call()
+    arb_balance = arb_balance / 10**18
 
-    contract = contracts["DAI"]
-    tx_params = contract.functions.mint(
-        ether_to_wei(100000), snx.address
-    ).build_transaction(
-        {
-            "from": SNX_DEPLOYER_ADDRESS,
-            "nonce": snx.web3.eth.get_transaction_count(SNX_DEPLOYER_ADDRESS),
-        }
-    )
+    # get some arb
+    if arb_balance < 100000:
+        transfer_amount = int((100000 - arb_balance) * 10**18)
+        snx.web3.provider.make_request("anvil_impersonateAccount", [ARB_WHALE])
 
-    # Send the transaction directly without signing
-    tx_hash = snx.web3.eth.send_transaction(tx_params)
-    receipt = snx.wait(tx_hash)
-    if receipt["status"] != 1:
-        raise Exception("DAI mint failed")
+        tx_params = arb_contract.functions.transfer(
+            snx.address, transfer_amount
+        ).build_transaction(
+            {
+                "from": ARB_WHALE,
+                "nonce": snx.web3.eth.get_transaction_count(ARB_WHALE),
+            }
+        )
 
-    assert tx_hash is not None
-    assert receipt is not None
-    assert receipt.status == 1
-    snx.logger.info(f"Minted DAI")
+        # Send the transaction directly without signing
+        tx_hash = snx.web3.eth.send_transaction(tx_params)
+        receipt = snx.wait(tx_hash)
+        if receipt["status"] != 1:
+            raise Exception("ARB Transfer failed")
 
-
-@pytest.fixture(scope="module")
-def mint_arb(snx, contracts):
-    """The instance can mint ARB tokens"""
-    snx.web3.provider.make_request("anvil_impersonateAccount", [SNX_DEPLOYER_ADDRESS])
-
-    contract = contracts["ARB"]
-    tx_params = contract.functions.mint(
-        ether_to_wei(100000), snx.address
-    ).build_transaction(
-        {
-            "from": SNX_DEPLOYER_ADDRESS,
-            "nonce": snx.web3.eth.get_transaction_count(SNX_DEPLOYER_ADDRESS),
-        }
-    )
-
-    # Send the transaction directly without signing
-    tx_hash = snx.web3.eth.send_transaction(tx_params)
-    receipt = snx.wait(tx_hash)
-    if receipt["status"] != 1:
-        raise Exception("ARB mint failed")
-
-    assert tx_hash is not None
-    assert receipt is not None
-    assert receipt.status == 1
-    snx.logger.info(f"Minted ARB")
+        assert tx_hash is not None
+        assert receipt is not None
+        assert receipt.status == 1
+        snx.logger.info(f"Stole ARB from {ARB_WHALE}")
 
 
 @pytest.fixture(scope="module")

--- a/src/tests/e2e/arbitrum-mainnet-fork/test_arb_mainnet_core.py
+++ b/src/tests/e2e/arbitrum-mainnet-fork/test_arb_mainnet_core.py
@@ -1,0 +1,213 @@
+import pytest
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# constants
+USD_TEST_AMOUNT = 1000
+USD_MINT_AMOUNT = 100
+
+WETH_TEST_AMOUNT = 1
+WETH_MINT_AMOUNT = 1000
+
+ARB_TEST_AMOUNT = 1000
+
+
+# tests
+def test_core_module(snx, logger):
+    """The instance has a core module"""
+    assert snx.core is not None
+    assert snx.core.core_proxy is not None
+
+
+@pytest.mark.parametrize(
+    "token_name, test_amount, decimals",
+    [
+        ("USDC", USD_TEST_AMOUNT, 6),
+        ("WETH", WETH_TEST_AMOUNT, 18),
+        ("ARB", ARB_TEST_AMOUNT, 18),
+    ],
+)
+def test_deposit_flow(
+    snx,
+    contracts,
+    core_account_id,
+    steal_usdc,
+    steal_arb,
+    wrap_eth,
+    token_name,
+    test_amount,
+    decimals,
+):
+    """The instance can deposit token"""
+    token = contracts[token_name]
+
+    # approve
+    allowance = snx.allowance(token.address, snx.core.core_proxy.address)
+    if allowance < test_amount:
+        approve_core_tx = snx.approve(
+            token.address, snx.core.core_proxy.address, submit=True
+        )
+        snx.wait(approve_core_tx)
+
+    # deposit the token
+    deposit_tx_hash = snx.core.deposit(
+        token.address,
+        test_amount,
+        decimals=decimals,
+        account_id=core_account_id,
+        submit=True,
+    )
+    deposit_tx_receipt = snx.wait(deposit_tx_hash)
+
+    assert deposit_tx_hash is not None
+    assert deposit_tx_receipt is not None
+    assert deposit_tx_receipt.status == 1
+
+    # withdraw the token
+    withdraw_tx_hash = snx.core.withdraw(
+        test_amount,
+        token_address=token.address,
+        decimals=decimals,
+        account_id=core_account_id,
+        submit=True,
+    )
+    withdraw_tx_receipt = snx.wait(withdraw_tx_hash)
+
+    assert withdraw_tx_hash is not None
+    assert withdraw_tx_receipt is not None
+    assert withdraw_tx_receipt.status == 1
+
+
+@pytest.mark.parametrize(
+    "token_name, test_amount, decimals",
+    [
+        ("USDC", USD_TEST_AMOUNT, 6),
+        ("WETH", WETH_TEST_AMOUNT, 18),
+        ("ARB", ARB_TEST_AMOUNT, 18),
+    ],
+)
+def test_delegate_flow(
+    snx,
+    contracts,
+    core_account_id,
+    steal_usdc,
+    steal_arb,
+    wrap_eth,
+    token_name,
+    test_amount,
+    decimals,
+):
+    """The instance can delegate token"""
+    token = contracts[token_name]
+
+    # approve
+    allowance = snx.allowance(token.address, snx.core.core_proxy.address)
+    if allowance < test_amount:
+        approve_core_tx = snx.approve(
+            token.address, snx.core.core_proxy.address, submit=True
+        )
+        snx.wait(approve_core_tx)
+
+    # deposit the token
+    deposit_tx_hash = snx.core.deposit(
+        token.address,
+        test_amount,
+        decimals=decimals,
+        account_id=core_account_id,
+        submit=True,
+    )
+    deposit_tx_receipt = snx.wait(deposit_tx_hash)
+
+    assert deposit_tx_hash is not None
+    assert deposit_tx_receipt is not None
+    assert deposit_tx_receipt.status == 1
+
+    # delegate the collateral
+    delegate_tx_hash = snx.core.delegate_collateral(
+        token.address,
+        test_amount,
+        1,
+        account_id=core_account_id,
+        submit=True,
+    )
+    delegate_tx_receipt = snx.wait(delegate_tx_hash)
+
+    assert delegate_tx_hash is not None
+    assert delegate_tx_receipt is not None
+    assert delegate_tx_receipt.status == 1
+
+
+@pytest.mark.parametrize(
+    "token_name, test_amount, mint_amount, decimals",
+    [
+        ("USDC", USD_TEST_AMOUNT, USD_MINT_AMOUNT, 6),
+        ("WETH", WETH_TEST_AMOUNT, USD_MINT_AMOUNT, 18),
+        ("ARB", ARB_TEST_AMOUNT, USD_MINT_AMOUNT, 18),
+    ],
+)
+def test_account_delegate_mint(
+    snx,
+    contracts,
+    core_account_id,
+    token_name,
+    steal_usdc,
+    steal_arb,
+    wrap_eth,
+    test_amount,
+    mint_amount,
+    decimals,
+):
+    """The instance can deposit and delegate"""
+    token = contracts[token_name]
+
+    # approve
+    allowance = snx.allowance(token.address, snx.core.core_proxy.address)
+    if allowance < test_amount:
+        approve_core_tx = snx.approve(
+            token.address, snx.core.core_proxy.address, submit=True
+        )
+        snx.wait(approve_core_tx)
+
+    # deposit the token
+    deposit_tx_hash = snx.core.deposit(
+        token.address,
+        test_amount,
+        decimals=decimals,
+        account_id=core_account_id,
+        submit=True,
+    )
+    deposit_tx_receipt = snx.wait(deposit_tx_hash)
+
+    assert deposit_tx_hash is not None
+    assert deposit_tx_receipt is not None
+    assert deposit_tx_receipt.status == 1
+
+    # delegate the collateral
+    delegate_tx_hash = snx.core.delegate_collateral(
+        token.address,
+        test_amount,
+        1,
+        account_id=core_account_id,
+        submit=True,
+    )
+    delegate_tx_receipt = snx.wait(delegate_tx_hash)
+
+    assert delegate_tx_hash is not None
+    assert delegate_tx_receipt is not None
+    assert delegate_tx_receipt.status == 1
+
+    # mint sUSD
+    mint_tx_hash = snx.core.mint_usd(
+        token.address,
+        mint_amount,
+        1,
+        account_id=core_account_id,
+        submit=True,
+    )
+
+    mint_tx_receipt = snx.wait(mint_tx_hash)
+
+    assert mint_tx_hash is not None
+    assert mint_tx_receipt is not None
+    assert mint_tx_receipt.status == 1

--- a/src/tests/e2e/arbitrum-mainnet-fork/test_arb_mainnet_spot.py
+++ b/src/tests/e2e/arbitrum-mainnet-fork/test_arb_mainnet_spot.py
@@ -1,0 +1,322 @@
+import pytest
+from synthetix.utils import ether_to_wei, wei_to_ether, format_wei
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# constants
+TEST_AMOUNT = 100
+
+# tests
+
+
+def test_spot_module(snx, logger):
+    """The instance has a spot module"""
+    assert snx.spot is not None
+    assert snx.spot.market_proxy is not None
+
+
+def test_spot_markets(snx, logger):
+    """The instance has spot markets"""
+    snx.logger.info(f"Markets: {snx.spot.markets_by_name}")
+    assert snx.spot.markets_by_name is not None
+    assert len(snx.spot.markets_by_name) == len(snx.spot.markets_by_id)
+    assert "sUSD" in snx.spot.markets_by_name
+    assert "sUSDC" in snx.spot.markets_by_name
+
+
+@pytest.mark.parametrize(
+    "token_name, test_amount, decimals",
+    [
+        ("USDC", TEST_AMOUNT, 6),
+    ],
+)
+def test_spot_wrapper(snx, contracts, steal_usdc, token_name, test_amount, decimals):
+    """The instance can wrap and unwrap an asset"""
+    token = contracts[token_name]
+    market_id = snx.spot.markets_by_name[f"s{token_name}"]["market_id"]
+    wrapped_token = snx.spot.markets_by_id[market_id]["contract"]
+
+    # make sure we have some USDC
+    starting_balance_wei = token.functions.balanceOf(snx.address).call()
+    starting_balance = format_wei(starting_balance_wei, decimals)
+
+    starting_synth_balance = snx.spot.get_balance(market_id=market_id)
+
+    assert starting_balance > test_amount
+
+    ## wrap
+    # check the allowance
+    allowance = snx.allowance(token.address, snx.spot.market_proxy.address)
+
+    if allowance < test_amount:
+        # approve
+        approve_tx = snx.approve(
+            token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    wrap_tx = snx.spot.wrap(test_amount, market_id=market_id, submit=True)
+    snx.wait(wrap_tx)
+
+    # get new balances
+    wrapped_balance_wei = token.functions.balanceOf(snx.address).call()
+    wrapped_balance = format_wei(wrapped_balance_wei, decimals)
+
+    wrapped_synth_balance = snx.spot.get_balance(market_id=market_id)
+
+    assert wrapped_balance == starting_balance - test_amount
+    assert wrapped_synth_balance == starting_synth_balance + test_amount
+
+    ## unwrap
+    # check the allowance
+    wrapped_allowance = snx.allowance(
+        wrapped_token.address, snx.spot.market_proxy.address
+    )
+
+    if wrapped_allowance < test_amount:
+        # approve
+        approve_tx = snx.approve(
+            wrapped_token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    unwrap_tx = snx.spot.wrap(-test_amount, market_id=market_id, submit=True)
+    snx.wait(unwrap_tx)
+
+    # get new balances
+    unwrapped_balance_wei = token.functions.balanceOf(snx.address).call()
+    unwrapped_balance = format_wei(unwrapped_balance_wei, decimals)
+
+    unwrapped_synth_balance = snx.spot.get_balance(market_id=market_id)
+
+    assert unwrapped_balance == wrapped_balance + test_amount
+    assert unwrapped_synth_balance == wrapped_synth_balance - test_amount
+
+
+@pytest.mark.parametrize(
+    "token_name, test_amount, decimals",
+    [
+        ("USDC", TEST_AMOUNT, 6),
+    ],
+)
+@pytest.mark.skip("Async orders are not working")
+def test_spot_async_order(
+    snx, contracts, steal_usdc, logger, token_name, test_amount, decimals
+):
+    """The instance can wrap USDC for sUSDC and commit an async order to sell for sUSD"""
+    token = contracts[token_name]
+    market_id = snx.spot.markets_by_name[f"s{token_name}"]["market_id"]
+    wrapped_token = snx.spot.markets_by_id[market_id]["contract"]
+
+    # make sure we have some USDC
+    starting_balance_wei = token.functions.balanceOf(snx.address).call()
+    starting_balance = format_wei(starting_balance_wei, decimals)
+
+    starting_synth_balance = snx.spot.get_balance(market_id=market_id)
+
+    assert starting_balance > test_amount
+
+    ## wrap
+    # check the allowance
+    allowance = snx.allowance(token.address, snx.spot.market_proxy.address)
+
+    if allowance < test_amount:
+        # approve
+        approve_tx = snx.approve(
+            token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    wrap_tx = snx.spot.wrap(test_amount, market_id=market_id, submit=True)
+    snx.wait(wrap_tx)
+
+    # get new balances
+    wrapped_balance_wei = token.functions.balanceOf(snx.address).call()
+    wrapped_balance = format_wei(wrapped_balance_wei, decimals)
+
+    wrapped_synth_balance = snx.spot.get_balance(market_id=market_id)
+
+    assert wrapped_balance == starting_balance - test_amount
+    assert wrapped_synth_balance == starting_synth_balance + test_amount
+
+    ## sell it
+    # check the allowance
+    wrapped_allowance = snx.allowance(
+        wrapped_token.address, snx.spot.market_proxy.address
+    )
+
+    if wrapped_allowance < test_amount:
+        # approve
+        approve_tx = snx.approve(
+            wrapped_token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    # commit order
+    commit_tx = snx.spot.commit_order(
+        "sell", test_amount, market_id=market_id, submit=True
+    )
+    commit_receipt = snx.wait(commit_tx)
+
+    # get the event to check the order id
+    event_data = snx.spot.market_proxy.events.OrderCommitted().process_receipt(
+        commit_receipt
+    )
+    assert len(event_data) == 1
+
+    # unpack the event
+    event = event_data[0]["args"]
+    market_id = event["marketId"]
+    async_order_id = event["asyncOrderId"]
+
+    # settle the order
+    settle_tx = snx.spot.settle_order(async_order_id, market_id=market_id, submit=True)
+    snx.logger.info(f"settle_tx: {settle_tx}")
+
+    assert settle_tx is not None
+
+
+@pytest.mark.parametrize(
+    "token_name, test_amount, decimals",
+    [
+        ("USDC", TEST_AMOUNT, 6),
+    ],
+)
+def test_spot_atomic_order(
+    snx, contracts, steal_usdc, logger, token_name, test_amount, decimals
+):
+    """The instance can wrap USDC for sUSDC and commit an atomic order to sell for sUSD"""
+    token = contracts[token_name]
+    market_id = snx.spot.markets_by_name[f"s{token_name}"]["market_id"]
+    wrapped_token = snx.spot.markets_by_id[market_id]["contract"]
+    susd_token = snx.spot.markets_by_id[0]["contract"]
+
+    # make sure we have some USDC
+    starting_balance_wei = token.functions.balanceOf(snx.address).call()
+    starting_balance = format_wei(starting_balance_wei, decimals)
+
+    starting_synth_balance = snx.spot.get_balance(market_id=market_id)
+    starting_susd_balance = snx.spot.get_balance(market_id=0)
+
+    assert starting_balance > test_amount
+
+    ## wrap
+    # check the allowance
+    allowance = snx.allowance(token.address, snx.spot.market_proxy.address)
+
+    if allowance < test_amount:
+        # approve
+        approve_tx = snx.approve(
+            token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    wrap_tx = snx.spot.wrap(test_amount, market_id=market_id, submit=True)
+    snx.wait(wrap_tx)
+
+    # get new balances
+    wrapped_balance_wei = token.functions.balanceOf(snx.address).call()
+    wrapped_balance = format_wei(wrapped_balance_wei, decimals)
+
+    wrapped_synth_balance = snx.spot.get_balance(market_id=market_id)
+
+    assert wrapped_balance == starting_balance - test_amount
+    assert wrapped_synth_balance == starting_synth_balance + test_amount
+
+    ## sell for sUSD
+    # check the allowance
+    wrapped_allowance = snx.allowance(
+        wrapped_token.address, snx.spot.market_proxy.address
+    )
+
+    if wrapped_allowance < test_amount:
+        # approve
+        approve_tx = snx.approve(
+            wrapped_token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    # atomic swap
+    swap_tx = snx.spot.atomic_order(
+        "sell", test_amount, slippage_tolerance=0.001, market_id=market_id, submit=True
+    )
+    swap_receipt = snx.wait(swap_tx)
+
+    assert swap_receipt is not None
+    assert swap_receipt.status == 1
+
+    # check balances
+    swapped_balance_wei = token.functions.balanceOf(snx.address).call()
+    swapped_balance = format_wei(swapped_balance_wei, decimals)
+
+    swapped_synth_balance = snx.spot.get_balance(market_id=market_id)
+    swapped_susd_balance = snx.spot.get_balance(market_id=0)
+
+    assert swapped_balance == starting_balance - test_amount
+    assert swapped_synth_balance == wrapped_synth_balance - test_amount
+    assert swapped_susd_balance > starting_susd_balance + (test_amount * 0.999)
+
+    ## buy wrapped token back
+    # check the allowance
+    susd_allowance = snx.allowance(susd_token.address, snx.spot.market_proxy.address)
+
+    if susd_allowance < test_amount:
+        # approve
+        approve_tx = snx.approve(
+            susd_token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    # atomic swap
+    buy_tx = snx.spot.atomic_order(
+        "buy",
+        swapped_susd_balance,
+        slippage_tolerance=0.001,
+        market_id=market_id,
+        submit=True,
+    )
+    buy_receipt = snx.wait(buy_tx)
+
+    assert buy_receipt is not None
+    assert buy_receipt.status == 1
+
+    # check balances
+    bought_balance_wei = token.functions.balanceOf(snx.address).call()
+    bought_balance = format_wei(bought_balance_wei, decimals)
+
+    bought_synth_balance = snx.spot.get_balance(market_id=market_id)
+    bought_susd_balance = snx.spot.get_balance(market_id=0)
+
+    assert bought_balance == swapped_balance
+    assert bought_synth_balance >= swapped_synth_balance + test_amount
+    assert bought_susd_balance == 0
+
+    ## unwrap
+    # check the allowance
+    wrapped_allowance = snx.allowance(
+        wrapped_token.address, snx.spot.market_proxy.address
+    )
+
+    if wrapped_allowance < bought_synth_balance:
+        # approve
+        approve_tx = snx.approve(
+            wrapped_token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    unwrap_tx = snx.spot.wrap(-test_amount, market_id=market_id, submit=True)
+    unwrap_receipt = snx.wait(unwrap_tx)
+
+    assert unwrap_tx is not None
+    assert unwrap_receipt is not None
+    assert unwrap_receipt.status == 1
+
+    # get new balances
+    unwrapped_balance_wei = token.functions.balanceOf(snx.address).call()
+    unwrapped_balance = format_wei(unwrapped_balance_wei, decimals)
+
+    unwrapped_synth_balance = snx.spot.get_balance(market_id=market_id)
+
+    assert unwrapped_balance == starting_balance
+    assert unwrapped_synth_balance == bought_synth_balance - test_amount

--- a/src/tests/e2e/arbitrum-mainnet-fork/test_arb_mainnet_synthetix.py
+++ b/src/tests/e2e/arbitrum-mainnet-fork/test_arb_mainnet_synthetix.py
@@ -1,0 +1,33 @@
+# tests
+
+
+def test_snx(snx):
+    """The instance has a Synthetix instance"""
+    assert snx is not None
+
+
+def test_contracts(contracts):
+    """The instance has necessary contracts"""
+    assert contracts["WETH"] is not None
+    assert contracts["USDC"] is not None
+    assert contracts["ARB"] is not None
+
+
+def test_wrap_eth(snx):
+    """The instance can wrap ETH"""
+    tx_hash = snx.wrap_eth(0.01, submit=True)
+    tx_receipt = snx.wait(tx_hash)
+
+    assert tx_hash is not None
+    assert tx_receipt is not None
+    assert tx_receipt.status == 1
+
+
+def test_unwrap_eth(snx):
+    """The instance can unwrap ETH"""
+    tx_hash = snx.wrap_eth(-0.01, submit=True)
+    tx_receipt = snx.wait(tx_hash)
+
+    assert tx_hash is not None
+    assert tx_receipt is not None
+    assert tx_receipt.status == 1

--- a/src/tests/e2e/arbitrum-sepolia-fork/test_arb_sepolia_core.py
+++ b/src/tests/e2e/arbitrum-sepolia-fork/test_arb_sepolia_core.py
@@ -24,7 +24,6 @@ def test_core_module(snx, logger):
     "token_name, test_amount, decimals",
     [
         ("USDC", USD_TEST_AMOUNT, 6),
-        ("DAI", USD_TEST_AMOUNT, 18),
         ("WETH", WETH_TEST_AMOUNT, 18),
         ("ARB", ARB_TEST_AMOUNT, 18),
     ],
@@ -34,7 +33,6 @@ def test_deposit_flow(
     contracts,
     core_account_id,
     steal_usdc,
-    mint_dai,
     mint_arb,
     wrap_eth,
     token_name,
@@ -85,7 +83,6 @@ def test_deposit_flow(
     "token_name, test_amount, decimals",
     [
         ("USDC", USD_TEST_AMOUNT, 6),
-        ("DAI", USD_TEST_AMOUNT, 18),
         ("WETH", WETH_TEST_AMOUNT, 18),
         ("ARB", ARB_TEST_AMOUNT, 18),
     ],
@@ -95,7 +92,6 @@ def test_delegate_flow(
     contracts,
     core_account_id,
     steal_usdc,
-    mint_dai,
     mint_arb,
     wrap_eth,
     token_name,
@@ -146,7 +142,6 @@ def test_delegate_flow(
     "token_name, test_amount, mint_amount, decimals",
     [
         ("USDC", USD_TEST_AMOUNT, USD_MINT_AMOUNT, 6),
-        ("DAI", USD_TEST_AMOUNT, USD_MINT_AMOUNT, 18),
         ("WETH", WETH_TEST_AMOUNT, USD_MINT_AMOUNT, 18),
         ("ARB", ARB_TEST_AMOUNT, USD_MINT_AMOUNT, 18),
     ],
@@ -157,7 +152,6 @@ def test_account_delegate_mint(
     core_account_id,
     token_name,
     steal_usdc,
-    mint_dai,
     mint_arb,
     wrap_eth,
     test_amount,

--- a/src/tests/e2e/arbitrum-sepolia-fork/test_arb_sepolia_spot.py
+++ b/src/tests/e2e/arbitrum-sepolia-fork/test_arb_sepolia_spot.py
@@ -23,19 +23,15 @@ def test_spot_markets(snx, logger):
     assert len(snx.spot.markets_by_name) == len(snx.spot.markets_by_id)
     assert "sUSD" in snx.spot.markets_by_name
     assert "sUSDC" in snx.spot.markets_by_name
-    assert "sDAI" in snx.spot.markets_by_name
 
 
 @pytest.mark.parametrize(
     "token_name, test_amount, decimals",
     [
         ("USDC", TEST_AMOUNT, 6),
-        ("DAI", TEST_AMOUNT, 18),
     ],
 )
-def test_spot_wrapper(
-    snx, contracts, steal_usdc, mint_dai, token_name, test_amount, decimals
-):
+def test_spot_wrapper(snx, contracts, steal_usdc, token_name, test_amount, decimals):
     """The instance can wrap and unwrap an asset"""
     token = contracts[token_name]
     market_id = snx.spot.markets_by_name[f"s{token_name}"]["market_id"]
@@ -102,12 +98,11 @@ def test_spot_wrapper(
     "token_name, test_amount, decimals",
     [
         ("USDC", TEST_AMOUNT, 6),
-        ("DAI", TEST_AMOUNT, 18),
     ],
 )
 @pytest.mark.skip("Async orders are not working")
 def test_spot_async_order(
-    snx, contracts, steal_usdc, mint_dai, logger, token_name, test_amount, decimals
+    snx, contracts, steal_usdc, logger, token_name, test_amount, decimals
 ):
     """The instance can wrap USDC for sUSDC and commit an async order to sell for sUSD"""
     token = contracts[token_name]
@@ -186,11 +181,10 @@ def test_spot_async_order(
     "token_name, test_amount, decimals",
     [
         ("USDC", TEST_AMOUNT, 6),
-        ("DAI", TEST_AMOUNT, 18),
     ],
 )
 def test_spot_atomic_order(
-    snx, contracts, steal_usdc, mint_dai, logger, token_name, test_amount, decimals
+    snx, contracts, steal_usdc, logger, token_name, test_amount, decimals
 ):
     """The instance can wrap USDC for sUSDC and commit an atomic order to sell for sUSD"""
     token = contracts[token_name]

--- a/src/tests/e2e/arbitrum-sepolia-fork/test_arb_sepolia_synthetix.py
+++ b/src/tests/e2e/arbitrum-sepolia-fork/test_arb_sepolia_synthetix.py
@@ -9,7 +9,6 @@ def test_snx(snx):
 def test_contracts(contracts):
     """The instance has necessary contracts"""
     assert contracts["WETH"] is not None
-    assert contracts["DAI"] is not None
     assert contracts["USDC"] is not None
     assert contracts["ARB"] is not None
 

--- a/src/tests/e2e/arbitrum-sepolia/conftest.py
+++ b/src/tests/e2e/arbitrum-sepolia/conftest.py
@@ -10,7 +10,7 @@ load_dotenv()
 # constants
 RPC = os.environ.get("NETWORK_421614_RPC")
 PRIVATE_KEY = os.environ.get("PRIVATE_KEY")
-MAINNET_RPC = os.environ.get("NETWORK_1_RPC")
+OP_MAINNET_RPC = os.environ.get("NETWORK_10_RPC")
 
 SNX_DEPLOYER_ADDRESS = "0x48914229deDd5A9922f44441ffCCfC2Cb7856Ee9"
 USDC_WHALE = "0x09eF1E9AA278C4A234a897c736fa933E9B2617a7"
@@ -23,7 +23,7 @@ def snx(pytestconfig):
     snx = Synthetix(
         provider_rpc=RPC,
         private_key=PRIVATE_KEY,
-        mainnet_rpc=MAINNET_RPC,
+        op_mainnet_rpc=OP_MAINNET_RPC,
         cannon_config={
             "package": "synthetix-omnibus",
             "version": "latest",

--- a/src/tests/e2e/base-mainnet-fork/conftest.py
+++ b/src/tests/e2e/base-mainnet-fork/conftest.py
@@ -23,6 +23,7 @@ def snx():
         provider_rpc=RPC,
         referrer=KWENTA_REFERRER,
         is_fork=True,
+        request_kwargs={"timeout": 120},
     )
 
     # check usdc balance


### PR DESCRIPTION
* Adds new argument to the init. This allows users to submit a request timeout for example, which is useful on forks.
* Adds the Arbitrum mainnet deploy
* Improves support for fork tests
