### PR TITLE
Bug: order settlement on forks

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="synthetix",
-    version="0.1.11",
+    version="0.1.12",
     description="Synthetix protocol SDK",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/src/synthetix/perps/perps.py
+++ b/src/synthetix/perps/perps.py
@@ -1034,15 +1034,16 @@ class Perps:
         expiration_time = (
             order["commitment_time"] + settlement_strategy["settlement_window_duration"]
         )
+        now_time = time.time() if not self.snx.is_fork else self.snx.web3.eth.get_block("latest")['timestamp']
 
         # check if order is ready to be settled
         if order["size_delta"] == 0:
             raise ValueError(f"Order is already settled for account {account_id}")
-        elif settlement_time > time.time():
-            duration = settlement_time - time.time()
+        elif settlement_time > now_time:
+            duration = settlement_time - now_time
             self.logger.info(f"Waiting {round(duration, 4)} seconds to settle order")
             time.sleep(duration)
-        elif expiration_time < time.time():
+        elif expiration_time < now_time:
             raise ValueError(f"Order has expired for account {account_id}")
         else:
             self.logger.info(f"Order is ready to be settled")

--- a/src/synthetix/spot/constants.py
+++ b/src/synthetix/spot/constants.py
@@ -1,0 +1,3 @@
+DISABLED_MARKETS = {
+    84532: [3]
+}

--- a/src/synthetix/spot/spot.py
+++ b/src/synthetix/spot/spot.py
@@ -710,21 +710,22 @@ class Spot:
         expiration_time = (
             order["commitment_time"] + settlement_strategy["settlement_window_duration"]
         )
-
+        now_time = time.time() if not self.snx.is_fork else self.snx.web3.eth.get_block("latest")['timestamp']
+        
         # check if order is ready to be settled
         if order["settled_at"] > 0:
             raise ValueError(
                 f"Order {async_order_id} on market {market_id} is already settled for account"
             )
-        elif settlement_time > time.time():
-            duration = settlement_time - time.time()
+        elif settlement_time > now_time:
+            duration = settlement_time - now_time
             self.logger.info(f"Waiting {round(duration, 4)} seconds")
             time.sleep(duration)
             self.logger.info(
                 f"Order {async_order_id} on market {market_id} is ready to be settled"
             )
 
-        elif expiration_time < time.time():
+        elif expiration_time < now_time:
             raise ValueError(
                 f"Order {async_order_id} on market {market_id} has expired"
             )


### PR DESCRIPTION
Set the current timestamp from the fork block timestamp when settling async orders on spot or perps markets.