### PR TITLE
Bug: Use stored RPC signers

### DIFF
--- a/src/synthetix/synthetix.py
+++ b/src/synthetix/synthetix.py
@@ -404,7 +404,7 @@ class Synthetix:
         :rtype: str
         """
 
-        is_rpc_signer = tx_data["from"] in self.web3.eth.accounts
+        is_rpc_signer = tx_data["from"] in self.rpc_signers
         if not is_rpc_signer and self.private_key is None:
             raise Exception("No private key specified.")
 


### PR DESCRIPTION
Fix a call to `web3.eth.accounts` which sometimes fails on public RPCs. Instead, use the stored RPC signers which is called safely at startup.