### PR TITLE
Arbitrum Mainnet Updates

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="synthetix",
-    version="0.1.16",
+    version="0.1.17",
     description="Synthetix protocol SDK",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/src/synthetix/contracts/deployments/42161/perpsFactory/PerpsAccountProxy.json
+++ b/src/synthetix/contracts/deployments/42161/perpsFactory/PerpsAccountProxy.json
@@ -809,6 +809,8 @@
     }
   ],
   "deployTxnHash": "",
+  "deployTxnBlockNumber": "",
+  "deployTimestamp": "",
   "sourceName": "",
   "contractName": "",
   "deployedOn": "invoke.init_account",

--- a/src/synthetix/contracts/deployments/42161/perpsFactory/PerpsMarketProxy.json
+++ b/src/synthetix/contracts/deployments/42161/perpsFactory/PerpsMarketProxy.json
@@ -1093,7 +1093,7 @@
       "inputs": [
         {
           "internalType": "uint128",
-          "name": "synthMarketId",
+          "name": "collateralId",
           "type": "uint128"
         },
         {
@@ -1113,13 +1113,13 @@
     {
       "inputs": [
         {
-          "internalType": "uint256",
-          "name": "availableUsdDenominated",
-          "type": "uint256"
+          "internalType": "int256",
+          "name": "withdrawableMarginUsd",
+          "type": "int256"
         },
         {
           "internalType": "uint256",
-          "name": "requiredUsdDenominated",
+          "name": "requestedMarginUsd",
           "type": "uint256"
         }
       ],
@@ -1130,7 +1130,7 @@
       "inputs": [
         {
           "internalType": "uint128",
-          "name": "synthMarketId",
+          "name": "collateralId",
           "type": "uint128"
         },
         {
@@ -1159,6 +1159,17 @@
       "type": "error"
     },
     {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "id",
+          "type": "uint128"
+        }
+      ],
+      "name": "InvalidId",
+      "type": "error"
+    },
+    {
       "inputs": [],
       "name": "KeeperCostsNotSet",
       "type": "error"
@@ -1167,7 +1178,7 @@
       "inputs": [
         {
           "internalType": "uint128",
-          "name": "synthMarketId",
+          "name": "collateralId",
           "type": "uint128"
         },
         {
@@ -1201,6 +1212,17 @@
       "type": "error"
     },
     {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "accountId",
+          "type": "uint128"
+        }
+      ],
+      "name": "NonexistentDebt",
+      "type": "error"
+    },
+    {
       "inputs": [],
       "name": "OverflowUint128ToInt128",
       "type": "error"
@@ -1225,7 +1247,7 @@
       "inputs": [
         {
           "internalType": "uint128",
-          "name": "synthMarketId",
+          "name": "collateralId",
           "type": "uint128"
         }
       ],
@@ -1244,7 +1266,7 @@
         {
           "indexed": true,
           "internalType": "uint128",
-          "name": "synthMarketId",
+          "name": "collateralId",
           "type": "uint128"
         },
         {
@@ -1262,6 +1284,69 @@
       ],
       "name": "CollateralModified",
       "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint128",
+          "name": "accountId",
+          "type": "uint128"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "DebtPaid",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint128",
+          "name": "superMarketId",
+          "type": "uint128"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint128",
+          "name": "interestRate",
+          "type": "uint128"
+        }
+      ],
+      "name": "InterestRateUpdated",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "accountId",
+          "type": "uint128"
+        }
+      ],
+      "name": "debt",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "accountDebt",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
       "inputs": [
@@ -1329,7 +1414,7 @@
         },
         {
           "internalType": "uint128",
-          "name": "synthMarketId",
+          "name": "collateralId",
           "type": "uint128"
         }
       ],
@@ -1464,7 +1549,7 @@
         },
         {
           "internalType": "uint128",
-          "name": "synthMarketId",
+          "name": "collateralId",
           "type": "uint128"
         },
         {
@@ -1474,6 +1559,24 @@
         }
       ],
       "name": "modifyCollateral",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "accountId",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "payDebt",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
@@ -1737,17 +1840,17 @@
     {
       "inputs": [
         {
-          "internalType": "uint256",
-          "name": "fillPrice",
-          "type": "uint256"
+          "internalType": "int256",
+          "name": "delegatedCollateral",
+          "type": "int256"
         },
         {
-          "internalType": "uint256",
-          "name": "acceptablePrice",
-          "type": "uint256"
+          "internalType": "int256",
+          "name": "newLockedCredit",
+          "type": "int256"
         }
       ],
-      "name": "AcceptablePriceExceeded",
+      "name": "ExceedsMarketCreditCapacity",
       "type": "error"
     },
     {
@@ -2293,11 +2396,16 @@
       "inputs": [
         {
           "internalType": "uint256",
-          "name": "leftover",
+          "name": "fillPrice",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "acceptablePrice",
           "type": "uint256"
         }
       ],
-      "name": "InsufficientAccountMargin",
+      "name": "AcceptablePriceExceeded",
       "type": "error"
     },
     {
@@ -2368,24 +2476,24 @@
       "inputs": [
         {
           "indexed": false,
-          "internalType": "uint256",
-          "name": "account",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
           "internalType": "uint128",
-          "name": "synthMarketId",
+          "name": "accountId",
           "type": "uint128"
         },
         {
           "indexed": false,
-          "internalType": "uint256",
+          "internalType": "int256",
           "name": "amount",
+          "type": "int256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "accountDebt",
           "type": "uint256"
         }
       ],
-      "name": "CollateralDeducted",
+      "name": "AccountCharged",
       "type": "event"
     },
     {
@@ -2937,7 +3045,45 @@
           "type": "uint128"
         }
       ],
+      "name": "AccountHasOpenPositions",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "id",
+          "type": "uint128"
+        },
+        {
+          "internalType": "address",
+          "name": "distributor",
+          "type": "address"
+        }
+      ],
+      "name": "InvalidDistributor",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "accountId",
+          "type": "uint128"
+        }
+      ],
       "name": "NotEligibleForLiquidation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "accountId",
+          "type": "uint128"
+        }
+      ],
+      "name": "NotEligibleForMarginLiquidation",
       "type": "error"
     },
     {
@@ -3012,6 +3158,31 @@
           "type": "uint128"
         },
         {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "seizedMarginValue",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "liquidationReward",
+          "type": "uint256"
+        }
+      ],
+      "name": "AccountMarginLiquidation",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint128",
+          "name": "accountId",
+          "type": "uint128"
+        },
+        {
           "indexed": true,
           "internalType": "uint128",
           "name": "marketId",
@@ -3042,6 +3213,25 @@
         }
       ],
       "name": "canLiquidate",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "isEligible",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "accountId",
+          "type": "uint128"
+        }
+      ],
+      "name": "canLiquidateMarginOnly",
       "outputs": [
         {
           "internalType": "bool",
@@ -3112,6 +3302,25 @@
         }
       ],
       "name": "liquidateFlaggedAccounts",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "liquidationReward",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "accountId",
+          "type": "uint128"
+        }
+      ],
+      "name": "liquidateMarginOnly",
       "outputs": [
         {
           "internalType": "uint256",
@@ -4128,6 +4337,263 @@
       "inputs": [
         {
           "internalType": "address",
+          "name": "distributor",
+          "type": "address"
+        }
+      ],
+      "name": "InvalidDistributorContract",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint128",
+          "name": "collateralId",
+          "type": "uint128"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "maxCollateralAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "upperLimitDiscount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "lowerLimitDiscount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "discountScalar",
+          "type": "uint256"
+        }
+      ],
+      "name": "CollateralConfigurationSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint128",
+          "name": "collateralLiquidateRewardRatioD18",
+          "type": "uint128"
+        }
+      ],
+      "name": "CollateralLiquidateRewardRatioSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "distributor",
+          "type": "address"
+        }
+      ],
+      "name": "RewardDistributorRegistered",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "collateralId",
+          "type": "uint128"
+        }
+      ],
+      "name": "getCollateralConfiguration",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "maxCollateralAmount",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "collateralId",
+          "type": "uint128"
+        }
+      ],
+      "name": "getCollateralConfigurationFull",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "maxCollateralAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "upperLimitDiscount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "lowerLimitDiscount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "discountScalar",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getCollateralLiquidateRewardRatio",
+      "outputs": [
+        {
+          "internalType": "uint128",
+          "name": "collateralLiquidateRewardRatioD18",
+          "type": "uint128"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "collateralId",
+          "type": "uint128"
+        }
+      ],
+      "name": "getRegisteredDistributor",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "distributor",
+          "type": "address"
+        },
+        {
+          "internalType": "address[]",
+          "name": "poolDelegatedCollateralTypes",
+          "type": "address[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "distributor",
+          "type": "address"
+        }
+      ],
+      "name": "isRegistered",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "distributor",
+          "type": "address"
+        },
+        {
+          "internalType": "uint128",
+          "name": "collateralId",
+          "type": "uint128"
+        },
+        {
+          "internalType": "address[]",
+          "name": "poolDelegatedCollateralTypes",
+          "type": "address[]"
+        }
+      ],
+      "name": "registerDistributor",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "collateralId",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxCollateralAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "upperLimitDiscount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "lowerLimitDiscount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "discountScalar",
+          "type": "uint256"
+        }
+      ],
+      "name": "setCollateralConfiguration",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "collateralLiquidateRewardRatioD18",
+          "type": "uint128"
+        }
+      ],
+      "name": "setCollateralLiquidateRewardRatio",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
           "name": "invalidFeeCollector",
           "type": "address"
         }
@@ -4166,25 +4632,6 @@
       "anonymous": false,
       "inputs": [
         {
-          "indexed": true,
-          "internalType": "uint128",
-          "name": "synthMarketId",
-          "type": "uint128"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "maxCollateralAmount",
-          "type": "uint256"
-        }
-      ],
-      "name": "CollateralConfigurationSet",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
           "indexed": false,
           "internalType": "address",
           "name": "feeCollector",
@@ -4217,25 +4664,6 @@
         }
       ],
       "name": "InterestRateParametersSet",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint128",
-          "name": "superMarketId",
-          "type": "uint128"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint128",
-          "name": "interestRate",
-          "type": "uint128"
-        }
-      ],
-      "name": "InterestRateUpdated",
       "type": "event"
     },
     {
@@ -4319,38 +4747,6 @@
       ],
       "name": "ReferrerShareUpdated",
       "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint128[]",
-          "name": "newSynthDeductionPriority",
-          "type": "uint128[]"
-        }
-      ],
-      "name": "SynthDeductionPrioritySet",
-      "type": "event"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint128",
-          "name": "synthMarketId",
-          "type": "uint128"
-        }
-      ],
-      "name": "getCollateralConfiguration",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "maxCollateralAmount",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
     },
     {
       "inputs": [],
@@ -4493,34 +4889,22 @@
       "type": "function"
     },
     {
-      "inputs": [],
-      "name": "getSynthDeductionPriority",
-      "outputs": [
-        {
-          "internalType": "uint128[]",
-          "name": "",
-          "type": "uint128[]"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
       "inputs": [
         {
           "internalType": "uint128",
-          "name": "synthMarketId",
+          "name": "collateralId",
           "type": "uint128"
-        },
+        }
+      ],
+      "name": "globalCollateralValue",
+      "outputs": [
         {
           "internalType": "uint256",
-          "name": "maxCollateralAmount",
+          "name": "collateralValue",
           "type": "uint256"
         }
       ],
-      "name": "setCollateralConfiguration",
-      "outputs": [],
-      "stateMutability": "nonpayable",
+      "stateMutability": "view",
       "type": "function"
     },
     {
@@ -4606,19 +4990,6 @@
       "type": "function"
     },
     {
-      "inputs": [
-        {
-          "internalType": "uint128[]",
-          "name": "newSynthDeductionPriority",
-          "type": "uint128[]"
-        }
-      ],
-      "name": "setSynthDeductionPriority",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
       "inputs": [],
       "name": "totalGlobalCollateralValue",
       "outputs": [
@@ -4671,6 +5042,8 @@
     }
   ],
   "deployTxnHash": "",
+  "deployTxnBlockNumber": "",
+  "deployTimestamp": "",
   "sourceName": "",
   "contractName": "",
   "deployedOn": "invoke.upgrade_proxy",

--- a/src/synthetix/contracts/deployments/42161/spotFactory/SpotMarketProxy.json
+++ b/src/synthetix/contracts/deployments/42161/spotFactory/SpotMarketProxy.json
@@ -233,6 +233,17 @@
     {
       "inputs": [
         {
+          "internalType": "uint128",
+          "name": "txnType",
+          "type": "uint128"
+        }
+      ],
+      "name": "InvalidTransactionTypeIndex",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
           "internalType": "bytes32",
           "name": "expected",
           "type": "bytes32"
@@ -670,6 +681,35 @@
           "internalType": "address",
           "name": "implAddress",
           "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "marketId",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint128",
+          "name": "transactionType",
+          "type": "uint128"
+        },
+        {
+          "internalType": "enum Price.Tolerance",
+          "name": "priceTolerance",
+          "type": "uint8"
+        }
+      ],
+      "name": "indexPrice",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "price",
+          "type": "uint256"
         }
       ],
       "stateMutability": "view",
@@ -3935,6 +3975,8 @@
     }
   ],
   "deployTxnHash": "",
+  "deployTxnBlockNumber": "",
+  "deployTimestamp": "",
   "sourceName": "",
   "contractName": "",
   "deployedOn": "invoke.upgradeSpotMarketProxy",

--- a/src/synthetix/contracts/deployments/42161/system/AccountProxy.json
+++ b/src/synthetix/contracts/deployments/42161/system/AccountProxy.json
@@ -809,6 +809,8 @@
     }
   ],
   "deployTxnHash": "",
+  "deployTxnBlockNumber": "",
+  "deployTimestamp": "",
   "sourceName": "",
   "contractName": "",
   "deployedOn": "invoke.init_account",

--- a/src/synthetix/contracts/deployments/42161/system/CoreProxy.json
+++ b/src/synthetix/contracts/deployments/42161/system/CoreProxy.json
@@ -2161,37 +2161,6 @@
         {
           "indexed": false,
           "internalType": "uint256",
-          "name": "feeAmount",
-          "type": "uint256"
-        }
-      ],
-      "name": "IssuanceFeePaid",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint128",
-          "name": "accountId",
-          "type": "uint128"
-        },
-        {
-          "indexed": true,
-          "internalType": "uint128",
-          "name": "poolId",
-          "type": "uint128"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "collateralType",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
           "name": "amount",
           "type": "uint256"
         },
@@ -2982,25 +2951,6 @@
         }
       ],
       "name": "MarketRegistered",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint128",
-          "name": "marketId",
-          "type": "uint128"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "feeAmount",
-          "type": "uint256"
-        }
-      ],
-      "name": "MarketSystemFeePaid",
       "type": "event"
     },
     {
@@ -4390,11 +4340,6 @@
       "type": "error"
     },
     {
-      "inputs": [],
-      "name": "RewardDistributorNotFound",
-      "type": "error"
-    },
-    {
       "inputs": [
         {
           "internalType": "address",
@@ -4558,6 +4503,40 @@
           "type": "address"
         }
       ],
+      "name": "claimPoolRewards",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "accountId",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint128",
+          "name": "poolId",
+          "type": "uint128"
+        },
+        {
+          "internalType": "address",
+          "name": "collateralType",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "distributor",
+          "type": "address"
+        }
+      ],
       "name": "claimRewards",
       "outputs": [
         {
@@ -4598,7 +4577,13 @@
         }
       ],
       "name": "distributeRewards",
-      "outputs": [],
+      "outputs": [
+        {
+          "internalType": "int256",
+          "name": "",
+          "type": "int256"
+        }
+      ],
       "stateMutability": "nonpayable",
       "type": "function"
     },
@@ -4636,7 +4621,47 @@
         }
       ],
       "name": "distributeRewardsByOwner",
-      "outputs": [],
+      "outputs": [
+        {
+          "internalType": "int256",
+          "name": "",
+          "type": "int256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "accountId",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint128",
+          "name": "poolId",
+          "type": "uint128"
+        },
+        {
+          "internalType": "address",
+          "name": "collateralType",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "distributor",
+          "type": "address"
+        }
+      ],
+      "name": "getAvailablePoolRewards",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
       "stateMutability": "nonpayable",
       "type": "function"
     },
@@ -4671,7 +4696,7 @@
           "type": "uint256"
         }
       ],
-      "stateMutability": "view",
+      "stateMutability": "nonpayable",
       "type": "function"
     },
     {
@@ -4778,6 +4803,11 @@
           "internalType": "address[]",
           "name": "",
           "type": "address[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
         }
       ],
       "stateMutability": "nonpayable",
@@ -5316,6 +5346,8 @@
     }
   ],
   "deployTxnHash": "",
+  "deployTxnBlockNumber": "",
+  "deployTimestamp": "",
   "sourceName": "",
   "contractName": "",
   "deployedOn": "invoke.upgrade_core_proxy",

--- a/src/synthetix/contracts/deployments/42161/system/USDProxy.json
+++ b/src/synthetix/contracts/deployments/42161/system/USDProxy.json
@@ -825,6 +825,8 @@
     }
   ],
   "deployTxnHash": "",
+  "deployTxnBlockNumber": "",
+  "deployTimestamp": "",
   "sourceName": "",
   "contractName": "",
   "deployedOn": "invoke.init_usd",

--- a/src/synthetix/contracts/deployments/42161/tBTC.json
+++ b/src/synthetix/contracts/deployments/42161/tBTC.json
@@ -1,0 +1,792 @@
+{
+    "address": "0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40",
+    "abi": [
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "guardian",
+                    "type": "address"
+                }
+            ],
+            "name": "GuardianAdded",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "guardian",
+                    "type": "address"
+                }
+            ],
+            "name": "GuardianRemoved",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "version",
+                    "type": "uint8"
+                }
+            ],
+            "name": "Initialized",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "minter",
+                    "type": "address"
+                }
+            ],
+            "name": "MinterAdded",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "minter",
+                    "type": "address"
+                }
+            ],
+            "name": "MinterRemoved",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Paused",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "Unpaused",
+            "type": "event"
+        },
+        {
+            "inputs": [],
+            "name": "DOMAIN_SEPARATOR",
+            "outputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "guardian",
+                    "type": "address"
+                }
+            ],
+            "name": "addGuardian",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "minter",
+                    "type": "address"
+                }
+            ],
+            "name": "addMinter",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                }
+            ],
+            "name": "allowance",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "approve",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                }
+            ],
+            "name": "balanceOf",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "burn",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "burnFrom",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "decimals",
+            "outputs": [
+                {
+                    "internalType": "uint8",
+                    "name": "",
+                    "type": "uint8"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "subtractedValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "decreaseAllowance",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "getGuardians",
+            "outputs": [
+                {
+                    "internalType": "address[]",
+                    "name": "",
+                    "type": "address[]"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "getMinters",
+            "outputs": [
+                {
+                    "internalType": "address[]",
+                    "name": "",
+                    "type": "address[]"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "name": "guardians",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "addedValue",
+                    "type": "uint256"
+                }
+            ],
+            "name": "increaseAllowance",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "string",
+                    "name": "_name",
+                    "type": "string"
+                },
+                {
+                    "internalType": "string",
+                    "name": "_symbol",
+                    "type": "string"
+                }
+            ],
+            "name": "initialize",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "isGuardian",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "isMinter",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "account",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "mint",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "name": "minters",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "name",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                }
+            ],
+            "name": "nonces",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "owner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "pause",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "paused",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "deadline",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint8",
+                    "name": "v",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "r",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "s",
+                    "type": "bytes32"
+                }
+            ],
+            "name": "permit",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "contract IERC20Upgradeable",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "recoverERC20",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "contract IERC721Upgradeable",
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "recoverERC721",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "guardian",
+                    "type": "address"
+                }
+            ],
+            "name": "removeGuardian",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "minter",
+                    "type": "address"
+                }
+            ],
+            "name": "removeMinter",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "renounceOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "symbol",
+            "outputs": [
+                {
+                    "internalType": "string",
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "totalSupply",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transfer",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferFrom",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "transferOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "unpause",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        }
+    ]
+}

--- a/src/synthetix/spot/spot.py
+++ b/src/synthetix/spot/spot.py
@@ -546,7 +546,16 @@ class Spot:
         """
         market_id, market_name = self._resolve_market(market_id, market_name)
 
-        if min_amount_received is None:
+        # first check if on Base where USDC and sUSD are 1:1
+        if (
+            self.snx.network_id in [8453, 84532]
+            and market_name == "sUSDC"
+            and min_amount_received is None
+        ):
+            # assume this is a 1:1 swap
+            min_amount_received = size
+            min_amount_received_wei = ether_to_wei(min_amount_received)
+        elif min_amount_received is None:
             # get the asset price
             token_symbol = self.markets_by_id[market_id]["symbol"]
             feed_id = self.snx.pyth.price_feed_ids[token_symbol]


### PR DESCRIPTION
- Update hard-coded contracts for the Arbitrum mainnet deployment
- Add the `tBTC` contract as hard-coded
- Adjust the atomic order function to correctly handle slippage
  - Additionally, hard-code a catch for USDC on Base, where instead of using an oracle price we specify 1:1 swaps. This change is backwards compatible, however future users can specify `min_amount_received` to override this.