### PR TITLE
remove excess print statement

### DIFF
--- a/src/synthetix/utils/multicall.py
+++ b/src/synthetix/utils/multicall.py
@@ -44,9 +44,7 @@ def decode_erc7412_oracle_data_required_error(snx, error):
     output_types = ["address", "bytes", "uint256"]
     try:
         address, data, fee = decode(output_types, error_data)
-        print("USED NORMAL output types")
     except:
-        print("USING BACKUP output types")
         address, data = decode(output_types[:2], error_data)
         fee = 0
 


### PR DESCRIPTION
This pull request includes a small change to the `decode_erc7412_oracle_data_required_error` function in the `src/synthetix/utils/multicall.py` file. The change removes print statements used for debugging purposes.

* [`src/synthetix/utils/multicall.py`](diffhunk://#diff-bdc7c8502e12571ec74c8a8e4d8caa2c41ae0132a8139c10a8847d8da9e08c47L47-L49): Removed print statements from the `decode_erc7412_oracle_data_required_error` function.