### PR TITLE
Fix default packaging

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="synthetix",
-    version="0.1.21",
+    version="0.1.22",
     description="Synthetix protocol SDK",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
@@ -24,6 +24,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     python_requires=">=3.8",
     include_package_data=True,

--- a/src/synthetix/contracts/contracts.py
+++ b/src/synthetix/contracts/contracts.py
@@ -1,6 +1,5 @@
 import os
 import json
-import glob
 import zlib
 import requests
 from web3 import Web3

--- a/src/synthetix/perps/perps.py
+++ b/src/synthetix/perps/perps.py
@@ -1,7 +1,7 @@
 """Modules for interacting with Synthetix Perps."""
 
 import time
-from eth_utils import encode_hex, decode_hex
+from eth_utils import encode_hex
 from ..utils import ether_to_wei, wei_to_ether
 from ..utils.multicall import (
     call_erc7412,
@@ -1157,10 +1157,8 @@ class PerpsV3(BasePerps):
         elif expiration_time < now_time:
             raise ValueError(f"Order has expired for account {account_id}")
         else:
-            self.logger.info(f"Order is ready to be settled")
+            self.logger.info("Order is ready to be settled")
 
-        # get fresh prices to provide to the oracle
-        market_name = self._resolve_market(order["market_id"], None)[1]
         # prepare the transaction
         tx_tries = 0
         while tx_tries < max_tx_tries:
@@ -1741,9 +1739,9 @@ class BfPerps(BasePerps):
         min_publish_delay = self.market_meta[market_id]["system_config"][
             "pyth_publish_time_min"
         ]
-        max_publish_delay = self.market_meta[market_id]["system_config"][
-            "pyth_publish_time_max"
-        ]
+        # max_publish_delay = self.market_meta[market_id]["system_config"][
+        #     "pyth_publish_time_max"
+        # ]
 
         commitment_time = order["commitment_time"]
         publish_time = commitment_time + min_publish_delay

--- a/src/synthetix/spot/spot.py
+++ b/src/synthetix/spot/spot.py
@@ -7,7 +7,6 @@ from .constants import DISABLED_MARKETS
 from web3.constants import ADDRESS_ZERO
 from typing import Literal
 import time
-import requests
 
 
 class Spot:


### PR DESCRIPTION
Fix the default packaging for the `trusted_multicall_forwarder` contract. It was removed from the `system` folder in recent Cannon packages, therefore `system.oracle_manager.trusted_multicall_forwarder` is a safer way to fetch the contract.