### PR TITLE
Fix Packaging

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="synthetix",
-    version="0.1.22",
+    version="0.1.23",
     description="Synthetix protocol SDK",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/src/synthetix/synthetix.py
+++ b/src/synthetix/synthetix.py
@@ -354,7 +354,15 @@ class Synthetix:
                 "trusted_multicall_forwarder"
             ]["TrustedMulticallForwarder"]
             mc_address = w3.to_checksum_address(mc_definition["address"])
-
+            multicall = w3.eth.contract(mc_address, abi=mc_definition["abi"])
+        elif (
+            "system" in self.contracts
+            and "trusted_multicall_forwarder" in self.contracts["system"]
+        ):
+            mc_definition = self.contracts["system"]["trusted_multicall_forwarder"][
+                "TrustedMulticallForwarder"
+            ]
+            mc_address = w3.to_checksum_address(mc_definition["address"])
             multicall = w3.eth.contract(mc_address, abi=mc_definition["abi"])
         else:
             multicall = None


### PR DESCRIPTION
Fix packaging backward compatibility by supporting both routes:
- `system.trusted_multicall_forwarder`
- `system.oracle_manager.trusted_multicall_forwarder`